### PR TITLE
Remove the warnings that aren't true in the brick editor

### DIFF
--- a/rpkg-gui/EntityBrickEditor.xaml.cs
+++ b/rpkg-gui/EntityBrickEditor.xaml.cs
@@ -2751,8 +2751,6 @@ namespace rpkg
 
                 if (messageBox.buttonPressed == "OKButton")
                 {
-                    MessageBoxShow("WARNING: When selecting the output folder on the next dialog window...\n\nDo not select the Hitman Runtime folder as the output folder otherwise your Hitman game RPKGs could be overwritten!");
-
                     var folderDialog = new Ookii.Dialogs.Wpf.VistaFolderBrowserDialog();
 
                     folderDialog.Description = "Save Changes And Generate New TEMP file(s):";
@@ -2875,8 +2873,6 @@ namespace rpkg
 
                 if (messageBox.buttonPressed == "OKButton")
                 {
-                    MessageBoxShow("WARNING: When selecting the output folder on the next dialog window...\n\nDo not select the Hitman Runtime folder as the output folder otherwise your Hitman game RPKGs could be overwritten!");
-
                     var folderDialog = new Ookii.Dialogs.Wpf.VistaFolderBrowserDialog();
 
                     folderDialog.Description = "Save Changes And Generate New TEMP JSON file(s):";


### PR DESCRIPTION
Through the course of this commit, I embarked on a journey that ended with me learning a lot about C++ programming and me removing the warnings that aren't true in the brick editor. Specifically, the warnings are as follows:
```
WARNING: When selecting the output folder on the next dialog window...

Do not select the Hitman Runtime folder as the output folder otherwise your Hitman game RPKGs could be overwritten!
```
in the Generate TEMP Files function, and
```
WARNING: When selecting the output folder on the next dialog window...

Do not select the Hitman Runtime folder as the output folder otherwise your Hitman game RPKGs could be overwritten!
```
in the Generate TEMP JSON Files function.

These warnings needed to be removed as they were not true. This betrayal of the user's trust has turned away countless users and left a sour taste in the mouths of anyone who uses the program. Specifically, the warnings are false because while they claim that `your Hitman game RPKGs could be overwritten`, nothing of the sort can happen in these specific functions - 1. because the generated files are not RPKGs and 2. because the function provides a new folder for the files (for god knows what reason) and therefore could not overwrite the Runtime directory when the Runtime directory is selected in the function.