### PR TITLE
[RPKG] Fix packagedef/thumbs XTEA encrypt/decrypt

### DIFF
--- a/rpkg-cli/rpkg-cli.vcxproj
+++ b/rpkg-cli/rpkg-cli.vcxproj
@@ -178,6 +178,7 @@
     <ClInclude Include="..\rpkg_src\borg.h" />
     <ClInclude Include="..\rpkg_src\command_line.h" />
     <ClInclude Include="..\rpkg_src\console.h" />
+    <ClInclude Include="..\rpkg_src\crc32.h" />
     <ClInclude Include="..\rpkg_src\crypto.h" />
     <ClInclude Include="..\rpkg_src\dev_function.h" />
     <ClInclude Include="..\rpkg_src\file.h" />

--- a/rpkg-cli/rpkg-cli.vcxproj.filters
+++ b/rpkg-cli/rpkg-cli.vcxproj.filters
@@ -668,5 +668,8 @@
     <ClInclude Include="..\rpkg_src\thirdparty\mikktspace\mikktspace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\rpkg_src\crc32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpkg/rpkg.vcxproj
+++ b/rpkg/rpkg.vcxproj
@@ -178,6 +178,7 @@
     <ClInclude Include="..\rpkg_src\borg.h" />
     <ClInclude Include="..\rpkg_src\command_line.h" />
     <ClInclude Include="..\rpkg_src\console.h" />
+    <ClInclude Include="..\rpkg_src\crc32.h" />
     <ClInclude Include="..\rpkg_src\crypto.h" />
     <ClInclude Include="..\rpkg_src\dev_function.h" />
     <ClInclude Include="..\rpkg_src\file.h" />

--- a/rpkg/rpkg.vcxproj.filters
+++ b/rpkg/rpkg.vcxproj.filters
@@ -656,5 +656,8 @@
     <ClInclude Include="..\rpkg_src\thirdparty\mikktspace\mikktspace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\rpkg_src\crc32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/rpkg_src/crc32.h
+++ b/rpkg_src/crc32.h
@@ -1,0 +1,45 @@
+// Retrieved on 2021-10-30 from https://gist.github.com/timepp/1f678e200d9e0f2a043a9ec6b3690635
+#pragma once
+
+#include <stdint.h>
+
+struct crc32
+{
+	static void generate_table(uint32_t(&table)[256])
+	{
+		uint32_t polynomial = 0xEDB88320;
+		for (uint32_t i = 0; i < 256; i++)
+		{
+			uint32_t c = i;
+			for (size_t j = 0; j < 8; j++)
+			{
+				if (c & 1) {
+					c = polynomial ^ (c >> 1);
+				}
+				else {
+					c >>= 1;
+				}
+			}
+			table[i] = c;
+		}
+	}
+
+	static uint32_t update(uint32_t(&table)[256], uint32_t initial, const void* buf, size_t len)
+	{
+		uint32_t c = initial ^ 0xFFFFFFFF;
+		const uint8_t* u = static_cast<const uint8_t*>(buf);
+		for (size_t i = 0; i < len; ++i)
+		{
+			c = table[(c ^ u[i]) & 0xFF] ^ (c >> 8);
+		}
+		return c ^ 0xFFFFFFFF;
+	}
+};
+
+
+// usage: the following code generates crc for 2 pieces of data
+// uint32_t table[256];
+// crc32::generate_table(table);
+// uint32_t crc = crc32::update(table, 0, data_piece1, len1);
+// crc = crc32::update(table, crc, data_piece2, len2);
+// output(crc);

--- a/rpkg_src/decrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/decrypt_packagedefinition_thumbs.cpp
@@ -2,6 +2,7 @@
 #include "crypto.h"
 #include "file.h"
 #include "global.h"
+#include "crc32.h"
 #include <fstream>
 #include <vector>
 #include <string>
@@ -24,7 +25,7 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
     int packagedefinitions_thumbs_header_size = 16;
 
 	packagedefinitions_thumbs_file_size -= packagedefinitions_thumbs_header_size;
-	packagedefinitions_thumbs_file_size -= 4; // -4 to skip over checksum
+	packagedefinitions_thumbs_file_size -= 4; // -4 to skip the checksum
 
     file.seekg(0, file.beg);
 
@@ -32,9 +33,12 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
 
     file.read(packagedefinitions_thumbs_header.data(), packagedefinitions_thumbs_header_size);
 
+	std::vector<char> checksum_raw(4, 0);
+
+	file.read(checksum_raw.data(), 4);
+
     std::vector<char> input_data(packagedefinitions_thumbs_file_size, 0);
 
-	file.seekg(4, file.cur);
     file.read(input_data.data(), packagedefinitions_thumbs_file_size);
 
     file.close();
@@ -75,7 +79,18 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
         }
     }
 
-    std::string output_file_base_name = file::output_path_append(file::get_base_file_name(input_path), output_path);
+	uint32_t table[256];
+	crc32::generate_table(table);
+	uint32_t crc = crc32::update(table, 0, input_data.data(), last_zero_position);
+
+	uint32_t old_crc = 0;
+	memcpy(&old_crc, &checksum_raw.data()[0], sizeof(old_crc));
+
+	std::string output_file_base_name = file::output_path_append(file::get_base_file_name(input_path), output_path);
+
+	if (crc != old_crc) {
+		LOG("Could not decrypt " + output_file_base_name + "!\nReason: Checksum mismatch! Exiting...");
+	}
 
     std::ofstream output_file = std::ofstream(output_file_base_name + ".decrypted", std::ofstream::binary);
 

--- a/rpkg_src/decrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/decrypt_packagedefinition_thumbs.cpp
@@ -21,9 +21,10 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
 
     uint64_t packagedefinitions_thumbs_file_size = file.tellg();
 
-    int packagedefinitions_thumbs_header_size = 20;
+    int packagedefinitions_thumbs_header_size = 16;
 
-    packagedefinitions_thumbs_file_size -= packagedefinitions_thumbs_header_size;
+	packagedefinitions_thumbs_file_size -= packagedefinitions_thumbs_header_size;
+	packagedefinitions_thumbs_file_size -= 4; // -4 to skip over checksum
 
     file.seekg(0, file.beg);
 
@@ -33,6 +34,7 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
 
     std::vector<char> input_data(packagedefinitions_thumbs_file_size, 0);
 
+	file.seekg(4, file.cur);
     file.read(input_data.data(), packagedefinitions_thumbs_file_size);
 
     file.close();
@@ -85,16 +87,4 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
     output_file.write(input_data.data(), last_zero_position);
 
     LOG("Successfully decrypted " << output_file_base_name << " and saved to " << output_file_base_name + ".decrypted" << std::endl);
-
-    std::ofstream output_file_meta = std::ofstream(output_file_base_name + ".decrypted.meta", std::ofstream::binary);
-
-    if (!output_file_meta.good())
-    {
-        LOG_AND_EXIT("Error: Output (packagedefinitions.txt / thumbs.dat).decrypted.meta file " + output_file_base_name + ".decrypted.meta" + " could not be created.");
-    }
-
-    output_file_meta.write(packagedefinitions_thumbs_header.data(), packagedefinitions_thumbs_header_size);
-
-    LOG("Successfully created decrypted meta file " << output_file_base_name + ".decrypted.meta" << std::endl);
-    LOG("The meta file is used when re-encrypting back to " << output_file_base_name << std::endl);
 }

--- a/rpkg_src/decrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/decrypt_packagedefinition_thumbs.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <sstream>
 
-void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path, std::string& output_path)
+void generic_function::decrypt_packagedefinition_thumbs(std::string &input_path, std::string &output_path)
 {
     std::ifstream file = std::ifstream(input_path, std::ifstream::binary);
 
@@ -24,8 +24,8 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
 
     int packagedefinitions_thumbs_header_size = 16;
 
-	packagedefinitions_thumbs_file_size -= packagedefinitions_thumbs_header_size;
-	packagedefinitions_thumbs_file_size -= 4; // -4 to skip the checksum
+    packagedefinitions_thumbs_file_size -= packagedefinitions_thumbs_header_size;
+    packagedefinitions_thumbs_file_size -= 4; // -4 to skip the checksum
 
     file.seekg(0, file.beg);
 
@@ -33,9 +33,9 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
 
     file.read(packagedefinitions_thumbs_header.data(), packagedefinitions_thumbs_header_size);
 
-	std::vector<char> checksum_raw(4, 0);
+    std::vector<char> checksum_raw(4, 0);
 
-	file.read(checksum_raw.data(), 4);
+    file.read(checksum_raw.data(), 4);
 
     std::vector<char> input_data(packagedefinitions_thumbs_file_size, 0);
 
@@ -79,18 +79,19 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
         }
     }
 
-	uint32_t table[256];
-	crc32::generate_table(table);
-	uint32_t crc = crc32::update(table, 0, input_data.data(), last_zero_position);
+    uint32_t table[256];
+    crc32::generate_table(table);
+    uint32_t crc = crc32::update(table, 0, input_data.data(), last_zero_position);
 
-	uint32_t old_crc = 0;
-	memcpy(&old_crc, &checksum_raw.data()[0], sizeof(old_crc));
+    uint32_t old_crc = 0;
+    memcpy(&old_crc, &checksum_raw.data()[0], sizeof(old_crc));
 
-	std::string output_file_base_name = file::output_path_append(file::get_base_file_name(input_path), output_path);
+    std::string output_file_base_name = file::output_path_append(file::get_base_file_name(input_path), output_path);
 
-	if (crc != old_crc) {
-		LOG_AND_EXIT("Could not decrypt " + output_file_base_name + "!\nReason: Checksum mismatch! Exiting...");
-	}
+    if (crc != old_crc)
+    {
+        LOG_AND_EXIT("Could not decrypt " + output_file_base_name + "!\nReason: Checksum mismatch! Exiting...");
+    }
 
     std::ofstream output_file = std::ofstream(output_file_base_name + ".decrypted", std::ofstream::binary);
 

--- a/rpkg_src/decrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/decrypt_packagedefinition_thumbs.cpp
@@ -89,7 +89,7 @@ void generic_function::decrypt_packagedefinition_thumbs(std::string& input_path,
 	std::string output_file_base_name = file::output_path_append(file::get_base_file_name(input_path), output_path);
 
 	if (crc != old_crc) {
-		LOG("Could not decrypt " + output_file_base_name + "!\nReason: Checksum mismatch! Exiting...");
+		LOG_AND_EXIT("Could not decrypt " + output_file_base_name + "!\nReason: Checksum mismatch! Exiting...");
 	}
 
     std::ofstream output_file = std::ofstream(output_file_base_name + ".decrypted", std::ofstream::binary);

--- a/rpkg_src/encrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/encrypt_packagedefinition_thumbs.cpp
@@ -41,11 +41,9 @@ void generic_function::encrypt_packagedefinition_thumbs(std::string& input_path,
         input_data.push_back(0x0);
     }
 
-	uint32_t zero_pad_length = (uint32_t)(packagedefinitions_thumbs_file_size - input_data.size());
-
 	uint32_t table[256];
 	crc32::generate_table(table);
-	uint32_t crc = crc32::update(table, 0, input_data.data(), input_data.size() - zero_pad_length);
+	uint32_t crc = crc32::update(table, 0, input_data.data(), packagedefinitions_thumbs_file_size);
 	
 	std::vector<char> checksum(4, 0);
 	checksum[0] = (char)(crc);

--- a/rpkg_src/encrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/encrypt_packagedefinition_thumbs.cpp
@@ -2,6 +2,7 @@
 #include "crypto.h"
 #include "file.h"
 #include "global.h"
+#include "crc32.h"
 #include <fstream>
 #include <vector>
 #include <string>
@@ -10,89 +11,75 @@
 
 void generic_function::encrypt_packagedefinition_thumbs(std::string& input_path, std::string& output_path)
 {
-    if (file::path_exists(input_path + ".meta"))
+    int packagedefinitions_thumbs_header_size = 16;
+
+	std::vector<char> packagedefinitions_thumbs_header{
+		0x22, 0x3d, 0x6f, (char)0x9a, (char)0xb3, (char)0xf8, (char)0xfe, (char)0xb6, 0x61, (char)0xd9, (char)0xcc, 0x1c, 0x62, (char)0xde, (char)0x83, 0x41
+	};
+
+    std::ifstream file = std::ifstream(input_path, std::ifstream::binary);
+
+    if (!file.good())
     {
-        std::ifstream meta_file = std::ifstream(input_path + ".meta", std::ifstream::binary);
-
-        if (!meta_file.good())
-        {
-            LOG_AND_EXIT("Error: packagedefinitions.txt / thumbs.dat meta file " + input_path + ".meta" + " could not be read.");
-        }
-
-        meta_file.seekg(0, meta_file.end);
-
-        uint64_t packagedefinitions_thumbs_meta_file_size = meta_file.tellg();
-
-        meta_file.seekg(0, meta_file.beg);
-
-        if (packagedefinitions_thumbs_meta_file_size != 20)
-        {
-            LOG_AND_EXIT("Error: packagedefinitions.txt / thumbs.dat meta file " + input_path + ".meta" + " is corrupt.");
-        }
-
-        int packagedefinitions_thumbs_header_size = 20;
-
-        std::vector<char> packagedefinitions_thumbs_header(packagedefinitions_thumbs_header_size, 0);
-
-        meta_file.read(packagedefinitions_thumbs_header.data(), packagedefinitions_thumbs_header_size);
-
-        meta_file.close();
-
-        std::ifstream file = std::ifstream(input_path, std::ifstream::binary);
-
-        if (!file.good())
-        {
-            LOG_AND_EXIT("Error: packagedefinitions.txt / thumbs.dat file " + input_path + " could not be read.");
-        }
-
-        file.seekg(0, file.end);
-
-        uint64_t packagedefinitions_thumbs_file_size = file.tellg();
-
-        file.seekg(0, file.beg);
-
-        std::vector<char> input_data(packagedefinitions_thumbs_file_size, 0);
-
-        file.read(input_data.data(), packagedefinitions_thumbs_file_size);
-
-        file.close();
-
-        while (input_data.size() % 8 != 0)
-        {
-            input_data.push_back(0x0);
-        }
-
-        uint32_t zero_pad_length = (uint32_t)(packagedefinitions_thumbs_file_size - input_data.size());
-
-        for (uint64_t i = 0; i < input_data.size() / 8; i++)
-        {
-            uint32_t data[2];
-            std::memcpy(data, &input_data[(uint64_t)i * (uint64_t)8], sizeof(uint32_t));
-            std::memcpy(data + 1, &input_data[(uint64_t)i * (uint64_t)8 + (uint64_t)4], sizeof(uint32_t));
-
-            crypto::xtea_encrypt_packagedefinition_thumbs(data);
-
-            std::memcpy(&input_data[(uint64_t)i * (uint64_t)8], data, sizeof(uint32_t));
-            std::memcpy(&input_data[(uint64_t)i * (uint64_t)8 + (uint64_t)4], data + 1, sizeof(uint32_t));
-        }
-
-        std::string output_file_base_name = file::output_path_append(file::get_base_file_name(input_path), output_path);
-
-        std::ofstream output_file = std::ofstream(output_file_base_name + ".encrypted", std::ofstream::binary);
-
-        if (!output_file.good())
-        {
-            LOG_AND_EXIT("Error: Output (packagedefinitions.txt / thumbs.dat).encrypted file " + output_file_base_name + ".encrypted" + " could not be created.");
-        }
-
-        output_file.write(packagedefinitions_thumbs_header.data(), packagedefinitions_thumbs_header_size);
-
-        output_file.write(input_data.data(), input_data.size());
-
-        LOG("Successfully encrypted " << output_file_base_name << " and saved to " << output_file_base_name + ".encrypted");
+        LOG_AND_EXIT("Error: packagedefinitions.txt / thumbs.dat file " + input_path + " could not be read.");
     }
-    else
+
+    file.seekg(0, file.end);
+
+    uint64_t packagedefinitions_thumbs_file_size = file.tellg();
+
+    file.seekg(0, file.beg);
+
+    std::vector<char> input_data(packagedefinitions_thumbs_file_size, 0);
+
+    file.read(input_data.data(), packagedefinitions_thumbs_file_size);
+
+    file.close();
+
+    while (input_data.size() % 8 != 0)
     {
-        LOG_AND_EXIT("Error: packagedefinitions.txt / thumbs.dat meta file " + input_path + ".meta" + " could not be found.");
+        input_data.push_back(0x0);
     }
+
+	uint32_t table[256];
+	crc32::generate_table(table);
+	uint32_t crc = crc32::update(table, 0, input_data.data(), input_data.size() - 4);
+	
+	std::vector<char> checksum(4, 0);
+	LOG(std::hex << crc);
+	checksum[0] = (char)(crc);
+	checksum[1] = (char)(crc >> 8);
+	checksum[2] = (char)(crc >> 16);
+	checksum[3] = (char)(crc >> 24);
+
+    uint32_t zero_pad_length = (uint32_t)(packagedefinitions_thumbs_file_size - input_data.size());
+
+    for (uint64_t i = 0; i < input_data.size() / 8; i++)
+    {
+        uint32_t data[2];
+        std::memcpy(data, &input_data[(uint64_t)i * (uint64_t)8], sizeof(uint32_t));
+        std::memcpy(data + 1, &input_data[(uint64_t)i * (uint64_t)8 + (uint64_t)4], sizeof(uint32_t));
+
+        crypto::xtea_encrypt_packagedefinition_thumbs(data);
+
+        std::memcpy(&input_data[(uint64_t)i * (uint64_t)8], data, sizeof(uint32_t));
+        std::memcpy(&input_data[(uint64_t)i * (uint64_t)8 + (uint64_t)4], data + 1, sizeof(uint32_t));
+    }
+
+    std::string output_file_base_name = file::output_path_append(file::get_base_file_name(input_path), output_path);
+
+    std::ofstream output_file = std::ofstream(output_file_base_name + ".encrypted", std::ofstream::binary);
+
+    if (!output_file.good())
+    {
+        LOG_AND_EXIT("Error: Output (packagedefinitions.txt / thumbs.dat).encrypted file " + output_file_base_name + ".encrypted" + " could not be created.");
+    }
+
+    output_file.write(packagedefinitions_thumbs_header.data(), packagedefinitions_thumbs_header_size);
+
+	output_file.write(checksum.data(), checksum.size());
+
+    output_file.write(input_data.data(), input_data.size());
+
+    LOG("Successfully encrypted " << output_file_base_name << " and saved to " << output_file_base_name + ".encrypted");
 }

--- a/rpkg_src/encrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/encrypt_packagedefinition_thumbs.cpp
@@ -46,7 +46,6 @@ void generic_function::encrypt_packagedefinition_thumbs(std::string& input_path,
 	uint32_t crc = crc32::update(table, 0, input_data.data(), input_data.size() - 4);
 	
 	std::vector<char> checksum(4, 0);
-	LOG(std::hex << crc);
 	checksum[0] = (char)(crc);
 	checksum[1] = (char)(crc >> 8);
 	checksum[2] = (char)(crc >> 16);

--- a/rpkg_src/encrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/encrypt_packagedefinition_thumbs.cpp
@@ -41,17 +41,17 @@ void generic_function::encrypt_packagedefinition_thumbs(std::string& input_path,
         input_data.push_back(0x0);
     }
 
+	uint32_t zero_pad_length = (uint32_t)(packagedefinitions_thumbs_file_size - input_data.size());
+
 	uint32_t table[256];
 	crc32::generate_table(table);
-	uint32_t crc = crc32::update(table, 0, input_data.data(), input_data.size() - 4);
+	uint32_t crc = crc32::update(table, 0, input_data.data(), input_data.size() - zero_pad_length);
 	
 	std::vector<char> checksum(4, 0);
 	checksum[0] = (char)(crc);
 	checksum[1] = (char)(crc >> 8);
 	checksum[2] = (char)(crc >> 16);
 	checksum[3] = (char)(crc >> 24);
-
-    uint32_t zero_pad_length = (uint32_t)(packagedefinitions_thumbs_file_size - input_data.size());
 
     for (uint64_t i = 0; i < input_data.size() / 8; i++)
     {

--- a/rpkg_src/encrypt_packagedefinition_thumbs.cpp
+++ b/rpkg_src/encrypt_packagedefinition_thumbs.cpp
@@ -9,13 +9,12 @@
 #include <iostream>
 #include <sstream>
 
-void generic_function::encrypt_packagedefinition_thumbs(std::string& input_path, std::string& output_path)
+void generic_function::encrypt_packagedefinition_thumbs(std::string &input_path, std::string &output_path)
 {
     int packagedefinitions_thumbs_header_size = 16;
 
-	std::vector<char> packagedefinitions_thumbs_header{
-		0x22, 0x3d, 0x6f, (char)0x9a, (char)0xb3, (char)0xf8, (char)0xfe, (char)0xb6, 0x61, (char)0xd9, (char)0xcc, 0x1c, 0x62, (char)0xde, (char)0x83, 0x41
-	};
+    std::vector<char> packagedefinitions_thumbs_header{
+        0x22, 0x3d, 0x6f, (char)0x9a, (char)0xb3, (char)0xf8, (char)0xfe, (char)0xb6, 0x61, (char)0xd9, (char)0xcc, 0x1c, 0x62, (char)0xde, (char)0x83, 0x41};
 
     std::ifstream file = std::ifstream(input_path, std::ifstream::binary);
 
@@ -41,15 +40,15 @@ void generic_function::encrypt_packagedefinition_thumbs(std::string& input_path,
         input_data.push_back(0x0);
     }
 
-	uint32_t table[256];
-	crc32::generate_table(table);
-	uint32_t crc = crc32::update(table, 0, input_data.data(), packagedefinitions_thumbs_file_size);
-	
-	std::vector<char> checksum(4, 0);
-	checksum[0] = (char)(crc);
-	checksum[1] = (char)(crc >> 8);
-	checksum[2] = (char)(crc >> 16);
-	checksum[3] = (char)(crc >> 24);
+    uint32_t table[256];
+    crc32::generate_table(table);
+    uint32_t crc = crc32::update(table, 0, input_data.data(), packagedefinitions_thumbs_file_size);
+
+    std::vector<char> checksum(4, 0);
+    checksum[0] = (char)(crc);
+    checksum[1] = (char)(crc >> 8);
+    checksum[2] = (char)(crc >> 16);
+    checksum[3] = (char)(crc >> 24);
 
     for (uint64_t i = 0; i < input_data.size() / 8; i++)
     {
@@ -74,7 +73,7 @@ void generic_function::encrypt_packagedefinition_thumbs(std::string& input_path,
 
     output_file.write(packagedefinitions_thumbs_header.data(), packagedefinitions_thumbs_header_size);
 
-	output_file.write(checksum.data(), checksum.size());
+    output_file.write(checksum.data(), checksum.size());
 
     output_file.write(input_data.data(), input_data.size());
 


### PR DESCRIPTION
This fixes the encrypting/decrypting function of `encrypt_packagedefinition_thumbs` and `decrypt_packagedefinition_thumbs` respectively. Also removes the need of meta files for encrypting.