### PR TITLE
Continued cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,6 @@ set(RPKG_COMMON_SOURCES
         src/extract_rpkg_meta.cpp
         src/extract_rtlv_to_json_from.cpp
         src/extract_sdef_to_json.cpp
-        src/extract_temp_from.cpp
         src/extract_text_from.cpp
         src/extract_to_rt_json.cpp
         src/extract_wwem_to_ogg_from.cpp

--- a/src/borg.cpp
+++ b/src/borg.cpp
@@ -4,7 +4,6 @@
 #include "crypto.h"
 #include "util.h"
 #include "thirdparty/lz4/lz4.h"
-#include <unordered_map>
 #include <fstream>
 
 borg::borg() = default;
@@ -36,7 +35,7 @@ borg::borg(uint64_t rpkgs_index, uint64_t hash_index) {
         LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(borg_rpkg_index).rpkg_file_path + " could not be read.");
     }
 
-    file.seekg(rpkgs.at(borg_rpkg_index).hash.at(borg_hash_index).data.header.data_offset, file.beg);
+    file.seekg(rpkgs.at(borg_rpkg_index).hash.at(borg_hash_index).data.header.data_offset, std::ifstream::beg);
     file.read(borg_input_data.data(), borg_hash_size);
     file.close();
 
@@ -59,39 +58,37 @@ borg::borg(uint64_t rpkgs_index, uint64_t hash_index) {
     std::vector<char>().swap(borg_input_data);
 
     char input[1024];
-    uint16_t bytes2 = 0;
-    uint32_t bytes4 = 0;
 
-    std::memcpy(&borg_primary_header_offset, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&borg_primary_header_offset, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
     borg_position = borg_primary_header_offset;
 
-    std::memcpy(&bones_count, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&bones_count, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&bones_count_animated, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&bones_count_animated, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&bones_offset, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&bones_offset, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&poses_offset, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&poses_offset, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&poses_inverse_matrices, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&poses_inverse_matrices, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&bones_constraints, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&bones_constraints, &borg_data.data()[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&poses_header, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&poses_header, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&bones_invert, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&bones_invert, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
-    std::memcpy(&bones_map, &borg_data.data()[borg_position], sizeof(bytes4));
+    std::memcpy(&bones_map, &borg_data[borg_position], BYTES4);
     borg_position += 0x4;
 
     borg_position = bones_offset;
@@ -99,7 +96,7 @@ borg::borg(uint64_t rpkgs_index, uint64_t hash_index) {
     if (log_output) {
         LOG("BORG file: " + borg_file_name);
 
-        std::unordered_map<uint64_t, uint64_t>::iterator it2 = hash_list_hash_map.find(
+        auto it2 = hash_list_hash_map.find(
                 rpkgs.at(borg_rpkg_index).hash.at(borg_hash_index).hash_value);
 
         if (it2 != hash_list_hash_map.end()) {
@@ -123,33 +120,33 @@ borg::borg(uint64_t rpkgs_index, uint64_t hash_index) {
     for (uint32_t b = 0; b < bones_count; b++) {
         bone_data temp_bone_data;
 
-        std::memcpy(&temp_bone_data.position.x, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_bone_data.position.x, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_bone_data.position.y, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_bone_data.position.y, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_bone_data.position.z, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_bone_data.position.z, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_bone_data.parent_id, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_bone_data.parent_id, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_bone_data.size.x, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_bone_data.size.x, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_bone_data.size.y, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_bone_data.size.y, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_bone_data.size.z, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_bone_data.size.z, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&input, &borg_data.data()[borg_position], 0x22);
+        std::memcpy(&input, &borg_data[borg_position], 0x22);
         borg_position += 0x22;
 
         temp_bone_data.name = std::string(input);
 
-        std::memcpy(&temp_bone_data.part, &borg_data.data()[borg_position], sizeof(bytes2));
+        std::memcpy(&temp_bone_data.part, &borg_data[borg_position], BYTES2);
         borg_position += 0x2;
 
         if (log_output) {
@@ -177,16 +174,16 @@ borg::borg(uint64_t rpkgs_index, uint64_t hash_index) {
         float temp_float_c = 0;
         float temp_float_d = 0;
 
-        std::memcpy(&temp_float_a, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_float_a, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_float_b, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_float_b, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_float_c, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_float_c, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_float_d, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_float_d, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
         DirectX::XMVECTOR temp_bone_quaternion;
@@ -197,16 +194,16 @@ borg::borg(uint64_t rpkgs_index, uint64_t hash_index) {
 
         vector4 temp_vector4;
 
-        std::memcpy(&temp_vector4.x, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_vector4.x, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_vector4.y, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_vector4.y, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_vector4.z, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_vector4.z, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&temp_vector4.w, &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&temp_vector4.w, &borg_data[borg_position], BYTES4);
         borg_position += 0x4;
 
         if (log_output) {
@@ -240,40 +237,40 @@ borg::borg(uint64_t rpkgs_index, uint64_t hash_index) {
     for (uint32_t b = 0; b < bones_count; b++) {
         DirectX::XMMATRIX inverse_bind_matrix = DirectX::XMMatrixIdentity();
 
-        std::memcpy(&inverse_bind_matrix.r[0].m128_f32[0], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[0].m128_f32[0], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[0].m128_f32[1], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[0].m128_f32[1], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[0].m128_f32[2], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[0].m128_f32[2], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[1].m128_f32[0], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[1].m128_f32[0], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[1].m128_f32[1], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[1].m128_f32[1], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[1].m128_f32[2], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[1].m128_f32[2], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[2].m128_f32[0], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[2].m128_f32[0], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[2].m128_f32[1], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[2].m128_f32[1], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[2].m128_f32[2], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[2].m128_f32[2], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[3].m128_f32[0], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[3].m128_f32[0], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[3].m128_f32[1], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[3].m128_f32[1], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
-        std::memcpy(&inverse_bind_matrix.r[3].m128_f32[2], &borg_data.data()[borg_position], sizeof(bytes4));
+        std::memcpy(&inverse_bind_matrix.r[3].m128_f32[2], &borg_data.data()[borg_position], BYTES4);
         borg_position += 0x4;
 
         if (log_output) {

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -29,11 +29,3 @@ struct crc32 {
         return c ^ 0xFFFFFFFF;
     }
 };
-
-
-// usage: the following code generates crc for 2 pieces of data
-// uint32_t table[256];
-// crc32::generate_table(table);
-// uint32_t crc = crc32::update(table, 0, data_piece1, len1);
-// crc = crc32::update(table, crc, data_piece2, len2);
-// output(crc);

--- a/src/dev_diff_rpkg_supermetas.cpp
+++ b/src/dev_diff_rpkg_supermetas.cpp
@@ -13,12 +13,7 @@
 // #include <unordered_map>
 
 void dev_function::dev_diff_rpkg_supermetas(std::string& input_path, std::string& filter, std::string& output_path) {
-    /*if (!hash_list_loaded)
-    {
-        LOG("Loading Hash List...");
-        generic_function::load_hash_list(true);
-        LOG("Loading Hash List: Done");
-    }
+    /*force_load_hash_list();
 
     input_path = file::parse_input_folder_path(input_path);
 

--- a/src/dev_dlge_names.cpp
+++ b/src/dev_dlge_names.cpp
@@ -15,11 +15,7 @@ void dev_function::dev_dlge_names(std::string& input_path, const std::string& ou
 
     nlohmann::ordered_json json;
 
-    if (!hash_list_loaded) {
-        LOG("Loading Hash List...");
-        generic_function::load_hash_list(true);
-        LOG("Loading Hash List: Done");
-    }
+    force_load_hash_list();
 
     for (uint64_t i = 0; i < rpkgs.size(); i++) {
         for (uint64_t r = 0; r < rpkgs.at(i).hash_resource_types.size(); r++) {
@@ -43,7 +39,7 @@ void dev_function::dev_dlge_names(std::string& input_path, const std::string& ou
 
                     nlohmann::ordered_json temp_json = nlohmann::ordered_json::array();
 
-                    for (const unsigned long long h : rpkgs.at(rpkg_index).hash.at(it->second).hash_reference_data.
+                    for (const uint64_t h : rpkgs.at(rpkg_index).hash.at(it->second).hash_reference_data.
                             hash_reference) {
                         temp_json.push_back(util::hash_to_ioi_string(h, true));
                     }

--- a/src/dev_extract_rpkg_supermetas.cpp
+++ b/src/dev_extract_rpkg_supermetas.cpp
@@ -119,7 +119,7 @@ void dev_function::dev_extract_rpkg_supermetas(std::string& input_path, std::str
 
                 if (temp_rpkg.rpkg_file_version == 2)
                 {
-                    file.read(input, sizeof(bytes4));
+                    file.read(input, BYTES4);
 
                     file.read(input, sizeof(bytes1));
                     std::memcpy(&bytes1, input, sizeof(bytes1));

--- a/src/dev_extract_wwem_strings.cpp
+++ b/src/dev_extract_wwem_strings.cpp
@@ -317,7 +317,7 @@ void dev_function::dev_extract_wwem_strings(std::string& input_path, std::string
                             }
 
                             for (uint64_t l = 0; l < text_search.length(); l++) {
-                                if (std::tolower(fxas_data->data()[position + l]) != std::tolower(text_search[l]))
+                                if (std::tolower((*fxas_data)[position + l]) != std::tolower(text_search[l]))
                                     break;
 
                                 if (l != text_search.length() - 1)
@@ -457,7 +457,6 @@ void dev_function::dev_extract_wwem_strings(std::string& input_path, std::string
                 uint32_t position = 0;
 
                 char input[1024];
-                uint32_t bytes4 = 0;
 
                 bool adtllabl_not_found = true;
 
@@ -489,7 +488,7 @@ void dev_function::dev_extract_wwem_strings(std::string& input_path, std::string
                 if (!adtllabl_not_found) {
                     position += static_cast<uint32_t>(adtllabl.length());
 
-                    std::memcpy(&wwem_file_name_length, (&(*wwem_data)[0] + position), sizeof(bytes4));
+                    std::memcpy(&wwem_file_name_length, (&(*wwem_data)[0] + position), BYTES4);
                     position += 0x8;
 
                     wwem_file_name_length -= 0x4;
@@ -682,7 +681,7 @@ void dev_function::dev_extract_wwem_strings(std::string& input_path, std::string
                                                      " could not be read.");
                                     }
 
-                                    file2.seekg(rpkgs.at(a).hash.at(hash_index2).data.header.data_offset, file2.beg);
+                                    file2.seekg(rpkgs.at(a).hash.at(hash_index2).data.header.data_offset, std::ifstream::beg);
                                     file2.read(input_data2.data(), hash_size);
                                     file2.close();
 
@@ -711,9 +710,8 @@ void dev_function::dev_extract_wwem_strings(std::string& input_path, std::string
                                     uint32_t position = 0;
 
                                     char input[1024];
-                                    uint32_t bytes4 = 0;
 
-                                    std::memcpy(&wwev_file_name_length, &(*wwev_data)[position], sizeof(bytes4));
+                                    std::memcpy(&wwev_file_name_length, &(*wwev_data)[position], BYTES4);
 
                                     std::vector<char> wwev_meta_data;
 

--- a/src/dev_extract_wwev_strings.cpp
+++ b/src/dev_extract_wwev_strings.cpp
@@ -53,7 +53,7 @@ void dev_function::dev_extract_wwev_strings(std::string& input_path, std::string
                     LOG_AND_EXIT("Error: RPKG file " + rpkg.rpkg_file_path + " could not be read.");
                 }
 
-                file.seekg(rpkg.hash.at(hash_index).data.header.data_offset, file.beg);
+                file.seekg(rpkg.hash.at(hash_index).data.header.data_offset, std::ifstream::beg);
                 file.read(input_data.data(), hash_size);
                 file.close();
 
@@ -83,9 +83,8 @@ void dev_function::dev_extract_wwev_strings(std::string& input_path, std::string
                 uint32_t position = 0;
 
                 char input[1024];
-                uint32_t bytes4 = 0;
 
-                std::memcpy(&wwev_file_name_length, &wwev_data->data()[position], sizeof(bytes4));
+                std::memcpy(&wwev_file_name_length, &(*wwev_data)[position], BYTES4);
 
                 std::vector<char> wwev_meta_data;
 
@@ -97,7 +96,7 @@ void dev_function::dev_extract_wwev_strings(std::string& input_path, std::string
                     wwev_meta_data.push_back(k);
                 }
 
-                std::memcpy(&input, &wwev_data->data()[position], (wwev_file_name_length + static_cast<uint64_t>(0xC)));
+                std::memcpy(&input, &(*wwev_data)[position], (wwev_file_name_length + static_cast<uint64_t>(0xC)));
                 for (uint64_t k = 0; k < (wwev_file_name_length + static_cast<uint64_t>(0xC)); k++) {
                     wwev_meta_data.push_back(input[k]);
                 }
@@ -108,14 +107,14 @@ void dev_function::dev_extract_wwev_strings(std::string& input_path, std::string
                         static_cast<uint64_t>(wwev_file_name_length) + static_cast<uint64_t>(1), 0);
                 wwev_file_name[wwev_file_name_length] = 0;
 
-                std::memcpy(wwev_file_name.data(), &wwev_data->data()[position], wwev_file_name_length);
+                std::memcpy(wwev_file_name.data(), &(*wwev_data)[position], wwev_file_name_length);
                 position += wwev_file_name_length;
                 position += 0x4;
 
-                std::memcpy(&wwev_file_count, &wwev_data->data()[position], sizeof(bytes4));
+                std::memcpy(&wwev_file_count, &(*wwev_data)[position], BYTES4);
                 position += 0x4;
 
-                std::memcpy(&wwev_file_count_test, &wwev_data->data()[position], sizeof(bytes4));
+                std::memcpy(&wwev_file_count_test, &(*wwev_data)[position], BYTES4);
 
                 current_path.append("\\");
                 current_path.append(std::string(wwev_file_name.data()));

--- a/src/dev_map_editor.cpp
+++ b/src/dev_map_editor.cpp
@@ -3,7 +3,6 @@
 #include "global.h"
 #include "file.h"
 #include "util.h"
-#include "crypto.h"
 #include "temp.h"
 #include <iostream>
 #include <filesystem>
@@ -20,204 +19,204 @@ void extract_glb_and_return_coords(uint32_t temps_index, uint32_t entry_index, s
                                    std::vector<bool>& entityId_has_m_mTransform_and_m_eidParent,
                                    std::unordered_map<std::string, uint64_t>& entityId_temp_index_entityIndex_map,
                                    std::vector<std::string>& entityId_m_mTransform) {
-    if (temps.at(temps_index).tblu_return_value == TEMP_TBLU_FOUND) {
-        std::string entry_name = "";
+    if (temps.at(temps_index).tblu_return_value != TEMP_TBLU_FOUND) return;
 
-        if (entry_index < 0 || entry_index >= temps.at(temps_index).tblu_entityName.size()) {
+    std::string entry_name = "";
 
+    if (entry_index < 0 || entry_index >= temps.at(temps_index).tblu_entityName.size()) {
+
+    } else {
+        entry_name.append(temps.at(temps_index).tblu_entityName.at(entry_index));
+    }
+
+    //util::replace_all_string_in_string(entry_name, " ", "_");
+
+    std::string property_name = "";
+
+    auto it4 = entityId_temp_index_entityIndex_map.find(
+            std::to_string(temps_index) + ":" + util::int32_t_to_string(entry_index));
+
+    if (it4 != entityId_temp_index_entityIndex_map.end()) {
+        if (entityId_has_m_mTransform_and_m_eidParent.at(it4->second)) {
+            property_name = entry_name + " (M) (" + util::uint32_t_to_string(temps_index) + "_" +
+                            util::uint32_t_to_string(entry_index) + ")";
+
+            if (!entry_name.empty()) {
+                map_editor_parents.push_back(parent_string);
+
+                if (parent_string.empty()) {
+                    parent_string += property_name;
+                } else {
+                    parent_string += "/" + property_name;
+                }
+
+                std::cout << parent_string << std::endl;
+
+                std::cout << entityId_m_mTransform.at(it4->second) << std::endl;
+
+                map_editor_property_names.push_back(property_name);
+
+                map_editor_matrixes.push_back(map_editor_temp_matrix);
+
+                map_editor_glb_file_names.push_back(prim_asset_file_names);
+
+                auto it = temps_map.find(rpkgs.at(temps.at(temps_index).temp_rpkg_index).hash.at(
+                        temps.at(temps_index).temp_hash_index).hash_reference_data.hash_reference.at(
+                        temps.at(temps_index).temp_entityTypeResourceIndex.at(entry_index)));
+
+                if (it != temps_map.end()) {
+                    if (temps.at(it->second).tblu_return_value == TEMP_TBLU_FOUND) {
+                        if (!temps.at(it->second).temp_depends_file_name.empty()) {
+                            std::set<uint32_t> logical_parents_set;
+
+                            for (uint32_t e = 0; e < temps.at(it->second).temp_logicalParent.size(); e++) {
+                                if (temps.at(it->second).temp_logicalParent.at(e) >=
+                                    temps.at(it->second).temp_logicalParent.size()) {
+                                    //logical_parents_set.insert(temps.at(it->second).temp_logicalParent.at(e));
+                                    logical_parents_set.insert(e);
+                                }
+                            }
+
+                            for (auto it2 = logical_parents_set.begin(); it2 != logical_parents_set.end(); it2++) {
+                                std::cout << *it2 << std::endl;
+
+                                auto it3 = temps_map.find(rpkgs.at(temps.at(it->second).temp_rpkg_index).hash.at(
+                                        temps.at(it->second).temp_hash_index).hash_reference_data.hash_reference.at(
+                                        temps.at(it->second).temp_entityTypeResourceIndex.at(*it2)));
+
+                                if (it3 != temps_map.end()) {
+                                    //if (temps.at(it3->second).tblu_return_value == TEMP_TBLU_FOUND)
+                                    //{
+                                    if (!temps.at(it3->second).prim_depends_file_name.empty()) {
+                                        for (const auto& p : temps.at(it3->second).prim_depends_file_name) {
+                                            std::cout << "PRIM: " << p << std::endl;
+                                        }
+                                    }
+                                    //}
+                                }
+                            }
+                        } else {
+                            if (!temps.at(it->second).prim_depends_file_name.empty()) {
+                                for (const auto& p : temps.at(it->second).prim_depends_file_name) {
+                                    std::cout << "PRIM: " << p << std::endl;
+                                }
+                            }
+                        }
+                    }
+
+                    if (!temps.at(it->second).prim_depends_file_name.empty()) {
+                        for (const auto& p : temps.at(it->second).prim_depends_file_name) {
+                            std::cout << "PRIM: " << p << std::endl;
+                        }
+                    }
+                }
+            }
         } else {
-            entry_name.append(temps.at(temps_index).tblu_entityName.at(entry_index));
+            property_name = entry_name + " (NM) (" + util::uint32_t_to_string(temps_index) + "_" +
+                            util::uint32_t_to_string(entry_index) + ")";
+
+            if (!entry_name.empty()) {
+                map_editor_parents.push_back(parent_string);
+
+                if (parent_string.empty()) {
+                    parent_string += property_name;
+                } else {
+                    parent_string += "/" + property_name;
+                }
+
+                std::cout << parent_string << std::endl;
+
+                map_editor_property_names.push_back(property_name);
+
+                map_editor_matrixes.push_back(map_editor_temp_matrix);
+
+                map_editor_glb_file_names.push_back(prim_asset_file_names);
+            }
         }
+    }
 
-        //util::replace_all_string_in_string(entry_name, " ", "_");
+    bool m_eidParent_found = false;
+    uint64_t entityId_temp = 0;
+    uint64_t m_eidParent_entityID = 0;
+    int32_t m_eidParent_entityIndex = 0;
 
-        std::string property_name = "";
-
-        auto it4 = entityId_temp_index_entityIndex_map.find(
+    if (entry_index >= 0 && entry_index < temps.at(temps_index).tblu_entityName.size()) {
+        std::pair<std::multimap<std::string, uint64_t>::iterator, std::multimap<std::string, uint64_t>::iterator> er = entityId_m_eidParent_entityIndex_map.equal_range(
                 std::to_string(temps_index) + ":" + util::int32_t_to_string(entry_index));
 
-        if (it4 != entityId_temp_index_entityIndex_map.end()) {
-            if (entityId_has_m_mTransform_and_m_eidParent.at(it4->second)) {
-                property_name = entry_name + " (M) (" + util::uint32_t_to_string(temps_index) + "_" +
-                                util::uint32_t_to_string(entry_index) + ")";
+        for (auto it3 = er.first; it3 != er.second; it3++) {
+            if (!entityId_entity_logicalParent_top_level.at(it3->second)) {
+                m_eidParent_found = true;
 
-                if (!entry_name.empty()) {
-                    map_editor_parents.push_back(parent_string);
+                entityId_temp = entityId_temp_index.at(it3->second);
 
-                    if (parent_string.empty()) {
-                        parent_string += property_name;
-                    } else {
-                        parent_string += "/" + property_name;
-                    }
+                m_eidParent_entityID = entityId_m_eidParent_entityID.at(it3->second);
 
+                m_eidParent_entityIndex = entityId_m_eidParent_entityIndex.at(it3->second);
+
+                extract_glb_and_return_coords(entityId_temp, m_eidParent_entityIndex, parent_string,
+                                              entityId_temp_index, entityId_m_eidParent_entityID,
+                                              entityId_m_eidParent_entityIndex,
+                                              entityId_m_eidParent_entityIndex_map,
+                                              entityId_entity_logicalParent_top_level,
+                                              entityId_has_m_mTransform_and_m_eidParent,
+                                              entityId_temp_index_entityIndex_map, entityId_m_mTransform);
+            }
+        }
+    }
+
+    if (!m_eidParent_found) {
+        bool logical_parent_found = false;
+
+        for (uint32_t e = 0; e < temps.at(temps_index).temp_logicalParent.size(); e++) {
+            if (temps.at(temps_index).temp_logicalParent.at(e) == entry_index) {
+                if (entry_index == 1) {
                     std::cout << parent_string << std::endl;
-
-                    std::cout << entityId_m_mTransform.at(it4->second) << std::endl;
-
-                    map_editor_property_names.push_back(property_name);
-
-                    map_editor_matrixes.push_back(map_editor_temp_matrix);
-
-                    map_editor_glb_file_names.push_back(prim_asset_file_names);
-
-                    auto it = temps_map.find(rpkgs.at(temps.at(temps_index).temp_rpkg_index).hash.at(
-                            temps.at(temps_index).temp_hash_index).hash_reference_data.hash_reference.at(
-                            temps.at(temps_index).temp_entityTypeResourceIndex.at(entry_index)));
-
-                    if (it != temps_map.end()) {
-                        if (temps.at(it->second).tblu_return_value == TEMP_TBLU_FOUND) {
-                            if (temps.at(it->second).temp_depends_file_name.size() > 0) {
-                                std::set<uint32_t> logical_parents_set;
-
-                                for (uint32_t e = 0; e < temps.at(it->second).temp_logicalParent.size(); e++) {
-                                    if (temps.at(it->second).temp_logicalParent.at(e) >=
-                                        temps.at(it->second).temp_logicalParent.size()) {
-                                        //logical_parents_set.insert(temps.at(it->second).temp_logicalParent.at(e));
-                                        logical_parents_set.insert(e);
-                                    }
-                                }
-
-                                for (auto it2 = logical_parents_set.begin(); it2 != logical_parents_set.end(); it2++) {
-                                    std::cout << *it2 << std::endl;
-
-                                    auto it3 = temps_map.find(rpkgs.at(temps.at(it->second).temp_rpkg_index).hash.at(
-                                            temps.at(it->second).temp_hash_index).hash_reference_data.hash_reference.at(
-                                            temps.at(it->second).temp_entityTypeResourceIndex.at(*it2)));
-
-                                    if (it3 != temps_map.end()) {
-                                        //if (temps.at(it3->second).tblu_return_value == TEMP_TBLU_FOUND)
-                                        //{
-                                        if (temps.at(it3->second).prim_depends_file_name.size() > 0) {
-                                            for (const auto& p : temps.at(it3->second).prim_depends_file_name) {
-                                                std::cout << "PRIM: " << p << std::endl;
-                                            }
-                                        }
-                                        //}
-                                    }
-                                }
-                            } else {
-                                if (temps.at(it->second).prim_depends_file_name.size() > 0) {
-                                    for (const auto& p : temps.at(it->second).prim_depends_file_name) {
-                                        std::cout << "PRIM: " << p << std::endl;
-                                    }
-                                }
-                            }
-                        }
-
-                        if (temps.at(it->second).prim_depends_file_name.size() > 0) {
-                            for (const auto& p : temps.at(it->second).prim_depends_file_name) {
-                                std::cout << "PRIM: " << p << std::endl;
-                            }
-                        }
-                    }
                 }
-            } else {
-                property_name = entry_name + " (NM) (" + util::uint32_t_to_string(temps_index) + "_" +
-                                util::uint32_t_to_string(entry_index) + ")";
 
-                if (!entry_name.empty()) {
-                    map_editor_parents.push_back(parent_string);
+                extract_glb_and_return_coords(temps_index, e, parent_string, entityId_temp_index,
+                                              entityId_m_eidParent_entityID, entityId_m_eidParent_entityIndex,
+                                              entityId_m_eidParent_entityIndex_map,
+                                              entityId_entity_logicalParent_top_level,
+                                              entityId_has_m_mTransform_and_m_eidParent,
+                                              entityId_temp_index_entityIndex_map, entityId_m_mTransform);
 
-                    if (parent_string.empty()) {
-                        parent_string += property_name;
-                    } else {
-                        parent_string += "/" + property_name;
-                    }
-
-                    std::cout << parent_string << std::endl;
-
-                    map_editor_property_names.push_back(property_name);
-
-                    map_editor_matrixes.push_back(map_editor_temp_matrix);
-
-                    map_editor_glb_file_names.push_back(prim_asset_file_names);
-                }
+                logical_parent_found = true;
             }
         }
+    }
 
-        bool m_eidParent_found = false;
-        uint64_t entityId_temp = 0;
-        uint64_t m_eidParent_entityID = 0;
-        int32_t m_eidParent_entityIndex = 0;
+    if (entry_index < 0 || entry_index >= temps.at(temps_index).tblu_entityName.size()) {
+        return;
+    }
 
-        if (entry_index >= 0 && entry_index < temps.at(temps_index).tblu_entityName.size()) {
-            std::pair<std::multimap<std::string, uint64_t>::iterator, std::multimap<std::string, uint64_t>::iterator> er = entityId_m_eidParent_entityIndex_map.equal_range(
-                    std::to_string(temps_index) + ":" + util::int32_t_to_string(entry_index));
+    auto it1 = temps_map.find(
+            rpkgs.at(temps.at(temps_index).temp_rpkg_index).hash.at(
+                    temps.at(temps_index).temp_hash_index).hash_reference_data.hash_reference.at(
+                    temps.at(temps_index).temp_entityTypeResourceIndex.at(entry_index)));
 
-            for (auto it3 = er.first; it3 != er.second; it3++) {
-                if (!entityId_entity_logicalParent_top_level.at(it3->second)) {
-                    m_eidParent_found = true;
+    if (it1 != temps_map.end()) {
+        if (temps.at(it1->second).tblu_return_value == TEMP_TBLU_FOUND) {
+            std::set<uint32_t> logicalParentsSet;
 
-                    entityId_temp = entityId_temp_index.at(it3->second);
-
-                    m_eidParent_entityID = entityId_m_eidParent_entityID.at(it3->second);
-
-                    m_eidParent_entityIndex = entityId_m_eidParent_entityIndex.at(it3->second);
-
-                    extract_glb_and_return_coords(entityId_temp, m_eidParent_entityIndex, parent_string,
-                                                  entityId_temp_index, entityId_m_eidParent_entityID,
-                                                  entityId_m_eidParent_entityIndex,
-                                                  entityId_m_eidParent_entityIndex_map,
-                                                  entityId_entity_logicalParent_top_level,
-                                                  entityId_has_m_mTransform_and_m_eidParent,
-                                                  entityId_temp_index_entityIndex_map, entityId_m_mTransform);
+            for (uint32_t e1 = 0; e1 < temps.at(it1->second).temp_logicalParent.size(); e1++) {
+                if (temps.at(it1->second).temp_logicalParent.at(e1) >=
+                    temps.at(it1->second).temp_logicalParent.size()) {
+                    logicalParentsSet.insert(temps.at(it1->second).temp_logicalParent.at(e1));
                 }
             }
-        }
 
-        if (!m_eidParent_found) {
-            bool logical_parent_found = false;
+            for (auto it21 = logicalParentsSet.begin();
+                 it21 != logicalParentsSet.end(); it21++) {
+                std::cout << *it21 << std::endl;
 
-            for (uint32_t e = 0; e < temps.at(temps_index).temp_logicalParent.size(); e++) {
-                if (temps.at(temps_index).temp_logicalParent.at(e) == entry_index) {
-                    if (entry_index == 1) {
-                        std::cout << parent_string << std::endl;
-                    }
-
-                    extract_glb_and_return_coords(temps_index, e, parent_string, entityId_temp_index,
-                                                  entityId_m_eidParent_entityID, entityId_m_eidParent_entityIndex,
-                                                  entityId_m_eidParent_entityIndex_map,
-                                                  entityId_entity_logicalParent_top_level,
-                                                  entityId_has_m_mTransform_and_m_eidParent,
-                                                  entityId_temp_index_entityIndex_map, entityId_m_mTransform);
-
-                    logical_parent_found = true;
-                }
+                extract_glb_and_return_coords(it1->second, *it21, parent_string, entityId_temp_index,
+                                              entityId_m_eidParent_entityID, entityId_m_eidParent_entityIndex,
+                                              entityId_m_eidParent_entityIndex_map,
+                                              entityId_entity_logicalParent_top_level,
+                                              entityId_has_m_mTransform_and_m_eidParent,
+                                              entityId_temp_index_entityIndex_map, entityId_m_mTransform);
             }
-        }
-
-        if (entry_index >= 0 && entry_index < temps.at(temps_index).tblu_entityName.size()) {
-            std::unordered_map<uint64_t, uint32_t>::iterator it = temps_map.find(
-                    rpkgs.at(temps.at(temps_index).temp_rpkg_index).hash.at(
-                            temps.at(temps_index).temp_hash_index).hash_reference_data.hash_reference.at(
-                            temps.at(temps_index).temp_entityTypeResourceIndex.at(entry_index)));
-
-            if (it != temps_map.end()) {
-                if (temps.at(it->second).tblu_return_value == TEMP_TBLU_FOUND) {
-                    std::set<uint32_t> logical_parents_set;
-
-                    for (uint32_t e = 0; e < temps.at(it->second).temp_logicalParent.size(); e++) {
-                        if (temps.at(it->second).temp_logicalParent.at(e) >=
-                            temps.at(it->second).temp_logicalParent.size()) {
-                            logical_parents_set.insert(temps.at(it->second).temp_logicalParent.at(e));
-                        }
-                    }
-
-                    for (auto it2 = logical_parents_set.begin();
-                         it2 != logical_parents_set.end(); it2++) {
-                        std::cout << *it2 << std::endl;
-
-                        extract_glb_and_return_coords(it->second, *it2, parent_string, entityId_temp_index,
-                                                      entityId_m_eidParent_entityID, entityId_m_eidParent_entityIndex,
-                                                      entityId_m_eidParent_entityIndex_map,
-                                                      entityId_entity_logicalParent_top_level,
-                                                      entityId_has_m_mTransform_and_m_eidParent,
-                                                      entityId_temp_index_entityIndex_map, entityId_m_mTransform);
-                    }
-                }
-            }
-        } else {
-
         }
     }
 }
@@ -235,10 +234,6 @@ void map_recursive_parent_mapper(uint64_t entityId, uint64_t entityId_index, con
                                  std::vector<uint64_t>& entityId_m_eidParent_entityID,
                                  std::vector<uint64_t>& entityId_m_eidParent_entityIndex) {
     if (entityId_m_eidParent_found.at(entityId_index)) {
-        if (entityId_entityName.at(entityId_index) == "mockup_commentbubble") {
-            std::cout << "LOL!!!" << std::endl;
-        }
-
         if (entityId_m_eidParent_entityID.at(entityId_index) == 0xFFFFFFFFFFFFFFFF) {
             std::string temp_entityId_temp_index = std::to_string(entityId_temp_index.at(entityId_index)) + ":" +
                                                    std::to_string(entityId_m_eidParent_entityIndex.at(entityId_index));
@@ -274,10 +269,6 @@ void map_recursive_parent_mapper(uint64_t entityId, uint64_t entityId_index, con
             }
         }
     } else if (!entityId_entity_logicalParent_top_level.at(entityId_index)) {
-        if (entityId_entityName.at(entityId_index) == "mockup_commentbubble") {
-            std::cout << "LOL!!!" << std::endl;
-        }
-
         std::string temp_entityId_temp_index = std::to_string(entityId_temp_index.at(entityId_index)) + ":" +
                                                std::to_string(entityId_entity_logicalParent_index.at(entityId_index));
 
@@ -296,10 +287,6 @@ void map_recursive_parent_mapper(uint64_t entityId, uint64_t entityId_index, con
             std::cout << parent_string << std::endl;
         }
     } else {
-        if (entityId_entityName.at(entityId_index) == "mockup_commentbubble") {
-            std::cout << "LOL!!!" << std::endl;
-        }
-
         bool found = false;
 
         std::pair<std::multimap<uint64_t, std::string>::iterator, std::multimap<uint64_t, std::string>::iterator> er = entityId_temp_entity_index_map_temp_hash_depend_map.equal_range(
@@ -335,11 +322,6 @@ void map_recursive_parent_mapper(uint64_t entityId, uint64_t entityId_index, con
 {
     if (entityId_m_eidParent_found.at(entityId_index))
     {
-        if (entityId_entityName.at(entityId_index) == "mockup_commentbubble")
-        {
-            std::cout << "LOL!!!" << std::endl;
-        }
-
         if (entityId_m_eidParent_entityID.at(entityId_index) == 0xFFFFFFFFFFFFFFFF)
         {
             std::string temp_entityId_temp_index = std::to_string(entityId_temp_index.at(entityId_index)) + ":" + std::to_string(entityId_m_eidParent_entityIndex.at(entityId_index));
@@ -371,11 +353,6 @@ void map_recursive_parent_mapper(uint64_t entityId, uint64_t entityId_index, con
     }
     else if (!entityId_entity_logicalParent_top_level.at(entityId_index))
     {
-        if (entityId_entityName.at(entityId_index) == "mockup_commentbubble")
-        {
-            std::cout << "LOL!!!" << std::endl;
-        }
-
         std::string temp_entityId_temp_index = std::to_string(entityId_temp_index.at(entityId_index)) + ":" + std::to_string(entityId_entity_logicalParent_index.at(entityId_index));
 
         std::unordered_map<std::string, uint64_t>::iterator itmap = entityId_temp_entity_index_map.find(temp_entityId_temp_index);
@@ -391,11 +368,6 @@ void map_recursive_parent_mapper(uint64_t entityId, uint64_t entityId_index, con
     }
     else
     {
-        if (entityId_entityName.at(entityId_index) == "mockup_commentbubble")
-        {
-            std::cout << "LOL!!!" << std::endl;
-        }
-
         bool found = false;
 
         std::pair <std::multimap<uint64_t, std::string>::iterator, std::multimap<uint64_t, std::string>::iterator> er = entityId_temp_entity_index_map_temp_hash_depend_map.equal_range(rpkgs.at(temps.at(entityId_temp_index.at(entityId_index)).temp_rpkg_index).hash.at(temps.at(entityId_temp_index.at(entityId_index)).temp_hash_index).hash_value);
@@ -468,11 +440,7 @@ void dev_function::dev_map_editor(std::string& input_path, std::string& filter, 
 
         //LOG("\r" + ss.str() + std::string((80 - ss.str().length()), ' '));
 
-        //LOG("Loading Hash List...");
-
-        //generic_function::load_hash_list(true);
-
-        //LOG("Loading Hash List: Done");
+        //force_load_hash_list();
 
         uint64_t temp_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
@@ -767,8 +735,6 @@ void dev_function::dev_map_editor(std::string& input_path, std::string& filter, 
                                 entityId_m_mTransform.push_back(m_mTransform);
                             }
                         }
-
-                        std::cout << "LOL!!!" << std::endl;
                     }
 
                     std::set<uint32_t> logical_parents_set;
@@ -972,8 +938,6 @@ void dev_function::dev_map_editor(std::string& input_path, std::string& filter, 
                                 }
                             }
                         }
-
-                        std::cout <<"LOL!!!" << std::endl;
                     }
 
                     for (std::unordered_map<uint64_t, uint64_t>::iterator itmap = entityId_map.begin(); itmap != entityId_map.end(); itmap++)

--- a/src/extract_all_hash_depends_from.cpp
+++ b/src/extract_all_hash_depends_from.cpp
@@ -6,10 +6,6 @@
 #include <unordered_map>
 #include <chrono>
 
-// we have to be recursive, no other way to do this
-#pragma clang diagnostic push
-#pragma ide diagnostic ignored "misc-no-recursion"
-
 void recursive_hash_depends_search(uint64_t hash_value, std::vector<uint64_t>& hashes_to_extract,
                                    std::unordered_map<uint64_t, uint64_t>& hashes_to_extract_map) {
     for (auto& rpkg : rpkgs) {
@@ -37,8 +33,6 @@ void recursive_hash_depends_search(uint64_t hash_value, std::vector<uint64_t>& h
         }
     }
 }
-
-#pragma clang diagnostic pop
 
 void
 rpkg_function::extract_all_hash_depends_from(std::string& input_path, std::string& unparsed_filters,

--- a/src/extract_all_prim_from.cpp
+++ b/src/extract_all_prim_from.cpp
@@ -31,12 +31,6 @@ rpkg_function::extract_all_prim_from(std::string& input_path, std::string& filte
         rpkg_function::import_rpkg(input_path, true);
     }
 
-    //LOG("Loading Hash List...");
-
-    //generic_function::load_hash_list(true);
-
-    //LOG("Loading Hash List: Done");
-
     std::stringstream ss;
 
     ss << "Scanning folder: Done";
@@ -134,9 +128,9 @@ rpkg_function::extract_all_prim_from(std::string& input_path, std::string& filte
     std::vector<std::string> not_found_in;
 
     for (uint64_t z = 0; z < filters.size(); z++) {
-        found_in.push_back("");
+        found_in.emplace_back("");
 
-        not_found_in.push_back("");
+        not_found_in.emplace_back("");
     }
 
     for (auto& rpkg : rpkgs) {
@@ -169,8 +163,8 @@ rpkg_function::extract_all_prim_from(std::string& input_path, std::string& filte
 
                     prim_count_current++;
 
-                    if (!extract_single_hash || (extract_single_hash && filter == util::uint64_t_to_hex_string(
-                            rpkg.hash.at(hash_index).hash_value))) {
+                    if (!extract_single_hash || filter == util::uint64_t_to_hex_string(
+                            rpkg.hash.at(hash_index).hash_value)) {
                         std::string hash_file_name =
                                 util::uint64_t_to_hex_string(rpkg.hash.at(hash_index).hash_value) + "." +
                                 rpkg.hash.at(hash_index).hash_resource_type;

--- a/src/extract_all_prim_model_from.cpp
+++ b/src/extract_all_prim_model_from.cpp
@@ -134,9 +134,9 @@ rpkg_function::extract_all_prim_model_from(std::string& input_path, std::string&
     std::vector<std::string> not_found_in;
 
     for (uint64_t z = 0; z < filters.size(); z++) {
-        found_in.push_back("");
+        found_in.emplace_back("");
 
-        not_found_in.push_back("");
+        not_found_in.emplace_back("");
     }
 
     for (auto& rpkg : rpkgs) {
@@ -167,8 +167,8 @@ rpkg_function::extract_all_prim_model_from(std::string& input_path, std::string&
 
                         prim_count_current++;
 
-                        if (!extract_single_hash || (extract_single_hash && filter == util::uint64_t_to_hex_string(
-                                rpkg.hash.at(hash_index).hash_value))) {
+                        if (!extract_single_hash || filter == util::uint64_t_to_hex_string(
+                                rpkg.hash.at(hash_index).hash_value)) {
                             std::string hash_file_name =
                                     util::uint64_t_to_hex_string(rpkg.hash.at(hash_index).hash_value) + "." +
                                     rpkg.hash.at(hash_index).hash_resource_type;

--- a/src/extract_all_prim_of_temp_from.cpp
+++ b/src/extract_all_prim_of_temp_from.cpp
@@ -53,28 +53,30 @@ void rpkg_function::extract_all_prim_of_temp_from(std::string& input_path, const
         for (uint64_t i = 0; i < rpkgs.size(); i++) {
             const uint64_t rpkg_index = i;
 
-            if (rpkgs.at(i).rpkg_file_path == input_path) {
-                auto it = rpkgs.at(rpkg_index).hash_map.find(temp_hash_value);
+            if (rpkgs.at(i).rpkg_file_path != input_path) continue;
 
-                if (it != rpkgs.at(rpkg_index).hash_map.end()) {
-                    if (gui_control == ABORT_CURRENT_TASK) {
-                        return;
-                    }
+            auto it = rpkgs.at(rpkg_index).hash_map.find(temp_hash_value);
 
-                    std::string temp_hash_file_name =
-                            util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) + "." +
-                            rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type;
+            if (it == rpkgs.at(rpkg_index).hash_map.end()) {
+                continue;
+            }
 
-                    if (rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type == "TEMP") {
-                        temp temp_temp(rpkg_index, it->second);
+            if (gui_control == ABORT_CURRENT_TASK) {
+                return;
+            }
 
-                        for (uint64_t j = 0; j < temp_temp.prim_depends_file_name.size(); j++) {
-                            rpkg_function::extract_prim_from(rpkgs.at(temp_temp.prim_depends_rpkg_index.at(j).at(
-                                                                     temp_temp.prim_depends_rpkg_index_index.at(j))).rpkg_file_path,
-                                                             temp_temp.prim_depends_file_name.at(j), output_path, type,
-                                                             true);
-                        }
-                    }
+            std::string temp_hash_file_name =
+                    util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) + "." +
+                    rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type;
+
+            if (rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type == "TEMP") {
+                temp temp_temp(rpkg_index, it->second);
+
+                for (uint64_t j = 0; j < temp_temp.prim_depends_file_name.size(); j++) {
+                    rpkg_function::extract_prim_from(rpkgs.at(temp_temp.prim_depends_rpkg_index.at(j).at(
+                                                             temp_temp.prim_depends_rpkg_index_index.at(j))).rpkg_file_path,
+                                                     temp_temp.prim_depends_file_name.at(j), output_path, type,
+                                                     true);
                 }
             }
         }

--- a/src/extract_all_text_from.cpp
+++ b/src/extract_all_text_from.cpp
@@ -79,9 +79,9 @@ void rpkg_function::extract_all_text_from(std::string& input_path, std::string& 
                         util::uint64_t_to_hex_string(rpkg.hash.at(hashIndex).hash_value) + "." +
                         rpkg.hash.at(hashIndex).hash_resource_type;
 
-                std::chrono::time_point endTime = std::chrono::high_resolution_clock::now();
+                const std::chrono::time_point endTime = std::chrono::high_resolution_clock::now();
 
-                double time_in_seconds_from_start_time = (0.000000001 *
+                const double time_in_seconds_from_start_time = (0.000000001 *
                                                           std::chrono::duration_cast<std::chrono::nanoseconds>(
                                                                   endTime - start_time).count());
 
@@ -168,8 +168,8 @@ void rpkg_function::extract_all_text_from(std::string& input_path, std::string& 
 
                     prim_count_current++;
 
-                    if (!extract_single_hash || (extract_single_hash && filter == util::uint64_t_to_hex_string(
-                            rpkg.hash.at(hash_index).hash_value))) {
+                    if (!extract_single_hash || filter == util::uint64_t_to_hex_string(
+                            rpkg.hash.at(hash_index).hash_value)) {
                         std::string hash_file_name =
                                 util::uint64_t_to_hex_string(rpkg.hash.at(hash_index).hash_value) + "." +
                                 rpkg.hash.at(hash_index).hash_resource_type;

--- a/src/extract_asva_to_json.cpp
+++ b/src/extract_asva_to_json.cpp
@@ -5,7 +5,6 @@
 #include "util.h"
 #include "asva.h"
 #include <chrono>
-#include <filesystem>
 #include <iostream>
 
 void rpkg_function::extract_asva_to_json(std::string& input_path, std::string& filter, std::string& output_path) {
@@ -14,68 +13,71 @@ void rpkg_function::extract_asva_to_json(std::string& input_path, std::string& f
 
     std::string input_rpkg_folder_path = file::parse_input_folder_path(input_path);
 
-    if (file::path_exists(input_rpkg_folder_path)) {
-        log_output = false;
+    if (!file::path_exists(input_rpkg_folder_path)) {
+        task_single_status = TASK_SUCCESSFUL;
+        task_multiple_status = TASK_SUCCESSFUL;
 
-        if (!hash_list_loaded) {
-            LOG("Loading Hash List...");
-            generic_function::load_hash_list(false);
-            LOG("Loading Hash List: Done");
-        }
+        LOG_AND_EXIT("Error: The RPKG file " + input_path + " does not exist.");
+    }
 
-        rpkg_function::import_rpkg_files_in_folder(input_rpkg_folder_path);
+    log_output = false;
 
-        std::vector<std::string> filters = util::parse_input_filter(filter);
+    if (!hash_list_loaded) {
+        LOG("Loading Hash List...");
+        generic_function::load_hash_list(false);
+        LOG("Loading Hash List: Done");
+    }
 
-        for (uint64_t f = 0; f < filters.size(); f++) {
-            uint64_t mati_hash_value = std::strtoull(filters.at(f).c_str(), nullptr, 16);
+    rpkg_function::import_rpkg_files_in_folder(input_rpkg_folder_path);
 
-            uint32_t rpkg_index = rpkg_function::get_latest_hash(mati_hash_value);
+    std::vector<std::string> filters = util::parse_input_filter(filter);
 
-            if (rpkg_index != UINT32_MAX) {
-                std::unordered_map<uint64_t, uint64_t>::iterator it = rpkgs.at(rpkg_index).hash_map.find(
-                        mati_hash_value);
+    for (uint64_t f = 0; f < filters.size(); f++) {
+        uint64_t mati_hash_value = std::strtoull(filters.at(f).c_str(), nullptr, 16);
 
-                if (it != rpkgs.at(rpkg_index).hash_map.end()) {
-                    timing_string = "Converting: " +
-                                    util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) +
-                                    "." + rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type + " to ASVA JSON";
+        uint32_t rpkg_index = rpkg_function::get_latest_hash(mati_hash_value);
 
-                    asva temp_material(rpkg_index, it->second);
+        if (rpkg_index != UINT32_MAX) {
+            std::unordered_map<uint64_t, uint64_t>::iterator it = rpkgs.at(rpkg_index).hash_map.find(
+                    mati_hash_value);
 
-                    std::string temp_output_path = "";
-                    bool output_path_is_dir = false;
+            if (it != rpkgs.at(rpkg_index).hash_map.end()) {
+                timing_string = "Converting: " +
+                                util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) +
+                                "." + rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type + " to ASVA JSON";
 
-                    if (output_path.length() > 5) {
-                        if (util::to_lower_case(output_path).substr(output_path.length() - 5) == ".json") {
-                            temp_output_path = output_path;
-                        } else {
-                            output_path_is_dir = true;
-                        }
+                asva temp_material(rpkg_index, it->second);
+
+                std::string temp_output_path;
+                bool output_path_is_dir = false;
+
+                if (output_path.length() > 5) {
+                    if (util::to_lower_case(output_path).substr(output_path.length() - 5) == ".json") {
+                        temp_output_path = output_path;
                     } else {
                         output_path_is_dir = true;
                     }
+                } else {
+                    output_path_is_dir = true;
+                }
 
-                    if (output_path_is_dir) {
-                        if (output_path != "") {
-                            file::create_directories(output_path);
-                        }
-
-                        temp_output_path = file::output_path_append(filters.at(f) + ".asva.json", output_path);
+                if (output_path_is_dir) {
+                    if (output_path != "") {
+                        file::create_directories(output_path);
                     }
 
-                    temp_material.generate_json();
-
-                    temp_material.write_json_to_file(temp_output_path);
+                    temp_output_path = file::output_path_append(filters.at(f) + ".asva.json", output_path);
                 }
+
+                temp_material.generate_json();
+
+                temp_material.write_json_to_file(temp_output_path);
             }
         }
-
-        log_output = true;
-
-        task_single_status = TASK_SUCCESSFUL;
-        task_multiple_status = TASK_SUCCESSFUL;
-    } else {
-        LOG_AND_EXIT("Error: The RPKG file " + input_path + " does not exist.");
     }
+
+    log_output = true;
+
+    task_single_status = TASK_SUCCESSFUL;
+    task_multiple_status = TASK_SUCCESSFUL;
 }

--- a/src/extract_direct_hash_depends_from.cpp
+++ b/src/extract_direct_hash_depends_from.cpp
@@ -2,12 +2,9 @@
 #include "file.h"
 #include "global.h"
 #include "util.h"
-#include "rpkg.h"
 #include "hash.h"
 #include <iostream>
-#include <unordered_map>
 #include <sstream>
-#include <filesystem>
 
 void
 rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::string& filter, std::string& output_path,
@@ -27,7 +24,7 @@ rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::st
         uint64_t hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
         for (uint64_t i = 0; i < rpkgs.size(); i++) {
-            std::unordered_map<uint64_t, uint64_t>::iterator it2 = rpkgs.at(i).hash_map.find(hash_value);
+            auto it2 = rpkgs.at(i).hash_map.find(hash_value);
 
             hash_depends_variables temp_hash_depends_data;
 
@@ -52,7 +49,7 @@ rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::st
                     bool found = false;
 
                     for (uint64_t j = 0; j < rpkgs.size(); j++) {
-                        std::unordered_map<uint64_t, uint64_t>::iterator it3 = rpkgs.at(j).hash_map.find(
+                        auto it3 = rpkgs.at(j).hash_map.find(
                                 rpkgs.at(i).hash.at(it2->second).hash_reference_data.hash_reference.at(k));
 
                         if (it3 == rpkgs.at(j).hash_map.end())
@@ -88,33 +85,33 @@ rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::st
         int rpkg_dependency_count = 0;
 
         for (auto& hash_depend : hash_depends_data) {
-            if (hash_depend.hash_dependency.size() > 0) {
+            if (!hash_depend.hash_dependency.empty()) {
                 rpkg_dependency_count++;
             }
         }
 
         LOG(filter << " has dependencies in " << rpkg_dependency_count << " RPKG files:" << std::endl);
 
-        for (uint64_t i = 0; i < hash_depends_data.size(); i++) {
-            if (hash_depends_data.at(i).hash_dependency.size() <= 0)
+        for (auto & i : hash_depends_data) {
+            if (i.hash_dependency.empty())
                 continue;
 
-            LOG(filter << " depends on " << hash_depends_data.at(i).hash_dependency_file_name.size()
-                       << " other hash files/resources in RPKG file: " << hash_depends_data.at(i).rpkg_file_name);
+            LOG(filter << " depends on " << i.hash_dependency_file_name.size()
+                       << " other hash files/resources in RPKG file: " << i.rpkg_file_name);
 
-            if (hash_depends_data.at(i).hash_dependency_file_name.size() > 0) {
+            if (!i.hash_dependency_file_name.empty()) {
                 LOG(filter << "'s dependencies:");
 
-                for (uint64_t j = 0; j < hash_depends_data.at(i).hash_dependency_file_name.size(); j++) {
-                    LOG_NO_ENDL("Hash file/resource: " << hash_depends_data.at(i).hash_dependency_file_name.at(j));
+                for (uint64_t j = 0; j < i.hash_dependency_file_name.size(); j++) {
+                    LOG_NO_ENDL("Hash file/resource: " << i.hash_dependency_file_name.at(j));
 
-                    if (hash_depends_data.at(i).hash_dependency_in_rpkg.at(j).size() > 0) {
+                    if (!i.hash_dependency_in_rpkg.at(j).empty()) {
                         LOG_NO_ENDL(", Found in RPKG files: ");
 
-                        for (uint64_t k = 0; k < hash_depends_data.at(i).hash_dependency_in_rpkg.at(j).size(); k++) {
-                            LOG_NO_ENDL(hash_depends_data.at(i).hash_dependency_in_rpkg.at(j).at(k));
+                        for (uint64_t k = 0; k < i.hash_dependency_in_rpkg.at(j).size(); k++) {
+                            LOG_NO_ENDL(i.hash_dependency_in_rpkg.at(j).at(k));
 
-                            if (k < hash_depends_data.at(i).hash_dependency_in_rpkg.at(j).size() - 1) {
+                            if (k < i.hash_dependency_in_rpkg.at(j).size() - 1) {
                                 LOG_NO_ENDL(", ");
                             }
                         }
@@ -183,13 +180,13 @@ rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::st
 
         LOG(filter << " has reverse dependencies in " << reverse_dependency.size() << " RPKG files:" << std::endl);
 
-        if (reverse_dependency.size() > 0) {
+        if (!reverse_dependency.empty()) {
             LOG(filter << "'s reverse dependencies:");
 
             for (uint64_t i = 0; i < reverse_dependency.size(); i++) {
                 LOG_NO_ENDL("Hash file/resource: " << reverse_dependency.at(i));
 
-                if (reverse_dependency_in_rpkg_file.at(i).size() > 0) {
+                if (!reverse_dependency_in_rpkg_file.at(i).empty()) {
                     LOG_NO_ENDL(", Found in RPKG files: ");
 
                     for (uint64_t j = 0; j < reverse_dependency_in_rpkg_file.at(i).size(); j++) {
@@ -214,7 +211,7 @@ rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::st
         std::string filter_hash_file_name = "";
 
         for (auto& rpkg : rpkgs) {
-            std::unordered_map<uint64_t, uint64_t>::iterator it = rpkg.hash_map.find(
+            auto it = rpkg.hash_map.find(
                     std::strtoull(filter.c_str(), nullptr, 16));
 
             if (it != rpkg.hash_map.end()) {
@@ -234,7 +231,7 @@ rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::st
         for (auto& rpkg : rpkgs) {
             uint64_t hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
-            std::unordered_map<uint64_t, uint64_t>::iterator it = rpkg.hash_map.find(hash_value);
+            auto it = rpkg.hash_map.find(hash_value);
 
             if (it != rpkg.hash_map.end()) {
                 uint32_t hash_reference_count =
@@ -250,7 +247,7 @@ rpkg_function::extract_direct_hash_depends_from(std::string& input_path, std::st
 
         for (uint64_t x = 0; x < hashes_to_extract.size(); x++) {
             for (auto& rpkg : rpkgs) {
-                std::unordered_map<uint64_t, uint64_t>::iterator it = rpkg.hash_map.find(hashes_to_extract.at(x));
+                auto it = rpkg.hash_map.find(hashes_to_extract.at(x));
 
                 if (it == rpkg.hash_map.end())
                     continue;

--- a/src/extract_dlge_to_json_from.cpp
+++ b/src/extract_dlge_to_json_from.cpp
@@ -96,10 +96,10 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
 
                 bool found = false;
 
-                for (uint64_t z = 0; z < filters.size(); z++) {
-                    std::size_t found_position = hash_file_name.find(filters.at(z));
+                for (const auto & filter : filters) {
+                    std::size_t found_position = hash_file_name.find(filter);
 
-                    if (found_position != std::string::npos && filters.at(z) != "") {
+                    if (found_position != std::string::npos && !filter.empty()) {
                         found = true;
 
                         break;
@@ -181,15 +181,15 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                 std::vector<std::vector<uint32_t>> language_string_sizes;
                 std::vector<std::vector<uint64_t>> language_string_metas;
                 std::vector<std::string> languages;
-                languages.push_back("en");
-                languages.push_back("fr");
-                languages.push_back("it");
-                languages.push_back("de");
-                languages.push_back("es");
-                languages.push_back("ru");
-                languages.push_back("cn");
-                languages.push_back("tc");
-                languages.push_back("jp");
+                languages.emplace_back("en");
+                languages.emplace_back("fr");
+                languages.emplace_back("it");
+                languages.emplace_back("de");
+                languages.emplace_back("es");
+                languages.emplace_back("ru");
+                languages.emplace_back("cn");
+                languages.emplace_back("tc");
+                languages.emplace_back("jp");
 
                 std::vector<char> json_meta_data;
 
@@ -201,9 +201,9 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                 uint32_t bytes4 = 0;
                 uint64_t bytes8 = 0;
 
-                std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
-                position += sizeof(bytes4);
+                position += BYTES4;
 
                 if (bytes4 != 0) {
                     LOG("Error: DLGE file " << hash_file_name << " in " << rpkgs.at(i).rpkg_file_name
@@ -211,9 +211,9 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                     break;
                 }
 
-                std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
-                position += sizeof(bytes4);
+                position += BYTES4;
 
                 if (bytes4 != 1) {
                     LOG("Error: DLGE file " << hash_file_name << " in " << rpkgs.at(i).rpkg_file_name
@@ -223,9 +223,9 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
 
                 uint8_t text_available = 0;
 
-                std::memcpy(&bytes1, &dlge_data->data()[position], sizeof(bytes1));
+                std::memcpy(&bytes1, &(*dlge_data)[position], BYTES1);
 
-                position += sizeof(bytes1);
+                position += BYTES1;
 
                 if (bytes1 == 1) {
                     text_available = 1;
@@ -240,29 +240,29 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                 while (text_available) {
                     number_of_dlge_categories++;
 
-                    std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                    std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
-                    for (uint64_t k = 0; k < sizeof(bytes4); k++) {
-                        json_meta_data.push_back(dlge_data->data()[position + k]);
+                    for (uint64_t k = 0; k < BYTES4; k++) {
+                        json_meta_data.push_back((*dlge_data)[position + k]);
                     }
 
-                    position += sizeof(bytes4);
+                    position += BYTES4;
 
                     dlge_categories.push_back(bytes4);
 
-                    std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                    std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
-                    for (uint64_t k = 0; k < sizeof(bytes4); k++) {
-                        json_meta_data.push_back(dlge_data->data()[position + k]);
+                    for (uint64_t k = 0; k < BYTES4; k++) {
+                        json_meta_data.push_back((*dlge_data)[position + k]);
                     }
 
-                    position += sizeof(bytes4);
+                    position += BYTES4;
 
                     dlge_identifiers.push_back(bytes4);
 
-                    std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                    std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
-                    position += sizeof(bytes4);
+                    position += BYTES4;
 
                     if (bytes4 != 0) {
                         LOG("Error: DLGE file " << hash_file_name << " in " << rpkgs.at(i).rpkg_file_name
@@ -271,9 +271,9 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                         break;
                     }
 
-                    std::memcpy(&bytes8, &dlge_data->data()[position], sizeof(bytes8));
+                    std::memcpy(&bytes8, &(*dlge_data)[position], BYTES8);
 
-                    position += sizeof(bytes8);
+                    position += BYTES8;
 
                     if (bytes8 != 0xFFFFFFFFFFFFFFFF) {
                         LOG("Error: DLGE file " << hash_file_name << " in " << rpkgs.at(i).rpkg_file_name
@@ -282,9 +282,9 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                         break;
                     }
 
-                    std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                    std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
-                    position += sizeof(bytes4);
+                    position += BYTES4;
 
                     if (bytes4 != 0) {
                         LOG("Error: DLGE file " << hash_file_name << " in " << rpkgs.at(i).rpkg_file_name
@@ -293,38 +293,38 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                         break;
                     }
 
-                    std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                    std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
                     if (bytes4 == 0) {
-                        for (uint64_t k = 0; k < sizeof(bytes4); k++) {
-                            json_meta_data.push_back(dlge_data->data()[position + k]);
+                        for (uint64_t k = 0; k < BYTES4; k++) {
+                            json_meta_data.push_back((*dlge_data)[position + k]);
                         }
 
-                        position += sizeof(bytes4);
+                        position += BYTES4;
                     }
 
                     uint32_t check_variable_1 = 0;
                     uint32_t check_variable_2 = 0;
 
-                    std::memcpy(&check_variable_1, &dlge_data->data()[position], sizeof(bytes4));
+                    std::memcpy(&check_variable_1, &(*dlge_data)[position], BYTES4);
 
-                    position += sizeof(bytes4);
+                    position += BYTES4;
 
-                    std::memcpy(&check_variable_2, &dlge_data->data()[position], sizeof(bytes4));
+                    std::memcpy(&check_variable_2, &(*dlge_data)[position], BYTES4);
 
-                    position += sizeof(bytes4);
+                    position += BYTES4;
 
-                    position -= sizeof(bytes8);
+                    position -= BYTES8;
 
                     if ((check_variable_1 == 0xFFFFFFFF && check_variable_2 == 0xFFFFFFFF) ||
                         ((check_variable_1 + 1) == check_variable_2) || check_variable_2 == 0xFFFFFFFF) {
-                        std::memcpy(&bytes8, &dlge_data->data()[position], sizeof(bytes8));
+                        std::memcpy(&bytes8, &(*dlge_data)[position], BYTES8);
 
-                        for (uint64_t k = 0; k < sizeof(bytes8); k++) {
-                            json_meta_data.push_back(dlge_data->data()[position + k]);
+                        for (uint64_t k = 0; k < BYTES8; k++) {
+                            json_meta_data.push_back((*dlge_data)[position + k]);
                         }
 
-                        position += sizeof(bytes8);
+                        position += BYTES8;
 
                         dlge_section_metas.push_back(bytes8);
                     } else {
@@ -347,15 +347,15 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
 
                         temp_language_json_object["Language"] = languages.at(number_of_languages);
 
-                        std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
-                        position += sizeof(bytes4);
+                        std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
+                        position += BYTES4;
 
                         temp_language_string_sizes.push_back(bytes4);
 
                         std::vector<char> temp_string;
 
                         for (uint64_t l = 0; l < temp_language_string_sizes.back(); l++) {
-                            temp_string.push_back(dlge_data->data()[position]);
+                            temp_string.push_back((*dlge_data)[position]);
                             position += 1;
                         }
 
@@ -383,10 +383,10 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                             dlge_has_text = true;
                         }
 
-                        uint32_t last_zero_position = static_cast<uint32_t>(temp_string.size());
+                        auto last_zero_position = static_cast<uint32_t>(temp_string.size());
 
                         if (!temp_string.empty()) {
-                            uint32_t m = static_cast<uint32_t>(temp_string.size() - 1);
+                            auto m = static_cast<uint32_t>(temp_string.size() - 1);
 
                             while (m >= 0) {
                                 if (temp_string.at(m) != 0) {
@@ -398,7 +398,7 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                             }
                         }
 
-                        if (temp_string.size() > 0) {
+                        if (!temp_string.empty()) {
                             std::string temp_string_with_zero_pad_removed = std::string(temp_string.begin(),
                                                                                         temp_string.end()).substr(0,
                                                                                                                   last_zero_position);
@@ -411,33 +411,33 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                         json_object.push_back(temp_language_json_object);
 
                         if ((position + 0x8) <= decompressed_size) {
-                            std::memcpy(&bytes4, &dlge_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&bytes4, &(*dlge_data)[position], BYTES4);
 
                             if (bytes4 == 0) {
-                                for (uint64_t k = 0; k < sizeof(bytes4); k++) {
-                                    json_meta_data.push_back(dlge_data->data()[position + k]);
+                                for (uint64_t k = 0; k < BYTES4; k++) {
+                                    json_meta_data.push_back((*dlge_data)[position + k]);
                                 }
 
-                                position += sizeof(bytes4);
+                                position += BYTES4;
                             }
 
-                            std::memcpy(&check_variable_1, &dlge_data->data()[position], sizeof(bytes4));
-                            position += sizeof(bytes4);
+                            std::memcpy(&check_variable_1, &(*dlge_data)[position], BYTES4);
+                            position += BYTES4;
 
-                            std::memcpy(&check_variable_2, &dlge_data->data()[position], sizeof(bytes4));
-                            position += sizeof(bytes4);
+                            std::memcpy(&check_variable_2, &(*dlge_data)[position], BYTES4);
+                            position += BYTES4;
 
-                            position -= sizeof(bytes8);
+                            position -= BYTES8;
 
                             if ((check_variable_1 == 0xFFFFFFFF && check_variable_2 == 0xFFFFFFFF) ||
                                 ((check_variable_1 + 1) == check_variable_2) || check_variable_2 == 0xFFFFFFFF) {
-                                std::memcpy(&bytes8, &dlge_data->data()[position], sizeof(bytes8));
+                                std::memcpy(&bytes8, &(*dlge_data)[position], BYTES8);
 
-                                for (uint64_t k = 0; k < sizeof(bytes8); k++) {
-                                    json_meta_data.push_back(dlge_data->data()[position + k]);
+                                for (uint64_t k = 0; k < BYTES8; k++) {
+                                    json_meta_data.push_back((*dlge_data)[position + k]);
                                 }
 
-                                position += sizeof(bytes8);
+                                position += BYTES8;
 
                                 temp_language_string_metas.push_back(bytes8);
                             } else {
@@ -451,12 +451,12 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
                     }
 
                     if ((position + 0x1) <= decompressed_size) {
-                        std::memcpy(&bytes1, &dlge_data->data()[position], sizeof(bytes1));
+                        std::memcpy(&bytes1, &(*dlge_data)[position], BYTES1);
 
                         if (bytes1 == 1) {
                             text_available = 1;
 
-                            position += sizeof(bytes1);
+                            position += BYTES1;
                         } else {
                             text_available = 0;
                         }
@@ -469,7 +469,7 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
 
                 if ((decompressed_size - position) > 0) {
                     for (uint64_t k = 0; k < (decompressed_size - position); k++) {
-                        json_meta_data.push_back(dlge_data->data()[position + k]);
+                        json_meta_data.push_back((*dlge_data)[position + k]);
                     }
                 }
 
@@ -507,11 +507,11 @@ void rpkg_function::extract_dlge_to_json_from(std::string& input_path, std::stri
 
                     char char4[4];
 
-                    std::memcpy(&char4, &number_of_dlge_categories, sizeof(bytes4));
-                    json_meta_file.write(char4, sizeof(bytes4));
+                    std::memcpy(&char4, &number_of_dlge_categories, BYTES4);
+                    json_meta_file.write(char4, BYTES4);
 
-                    std::memcpy(&char4, &number_of_languages, sizeof(bytes4));
-                    json_meta_file.write(char4, sizeof(bytes4));
+                    std::memcpy(&char4, &number_of_languages, BYTES4);
+                    json_meta_file.write(char4, BYTES4);
 
                     json_meta_file.write(json_meta_data.data(), json_meta_data.size());
 

--- a/src/extract_entity_to_qn.cpp
+++ b/src/extract_entity_to_qn.cpp
@@ -4,7 +4,6 @@
 #include "util.h"
 #include "generic_function.h"
 #include <iostream>
-#include <unordered_map>
 #include <chrono>
 #include <sstream>
 #include <filesystem>
@@ -45,11 +44,7 @@ void rpkg_function::extract_entity_to_qn(std::string& input_path, std::string& f
 
     //LOG("\r" + ss.str() + std::string((80 - ss.str().length()), ' '));
 
-    if (!hash_list_loaded) {
-        LOG("Loading Hash List...");
-        generic_function::load_hash_list(true);
-        LOG("Loading Hash List: Done");
-    }
+    force_load_hash_list();
 
     std::vector<std::string> filters = util::parse_input_filter(filter);
 
@@ -61,7 +56,7 @@ void rpkg_function::extract_entity_to_qn(std::string& input_path, std::string& f
         if (rpkg_index == UINT32_MAX)
             continue;
 
-        std::unordered_map<uint64_t, uint64_t>::iterator it6 = rpkgs.at(rpkg_index).hash_map.find(temp_hash_value);
+        auto it6 = rpkgs.at(rpkg_index).hash_map.find(temp_hash_value);
 
         if (it6 == rpkgs.at(rpkg_index).hash_map.end())
             continue;
@@ -99,7 +94,7 @@ void rpkg_function::extract_entity_to_qn(std::string& input_path, std::string& f
         }
 
         if (output_path_is_dir) {
-            if (output_path != "") {
+            if (!output_path.empty()) {
                 file::create_directories(output_path);
             }
 

--- a/src/extract_from_rpkg.cpp
+++ b/src/extract_from_rpkg.cpp
@@ -7,7 +7,6 @@
 #include "thirdparty/lz4/lz4.h"
 #include <iostream>
 #include <fstream>
-#include <regex>
 #include <sstream>
 
 void rpkg_function::extract_from_rpkg(rpkg_extraction_vars& rpkg_vars) {
@@ -73,7 +72,7 @@ void rpkg_function::extract_from_rpkg(rpkg_extraction_vars& rpkg_vars) {
             for (uint64_t z = 0; z < filters.size(); z++) {
                 std::size_t found_position = hash_file_name.find(filters.at(z));
 
-                if (found_position != std::string::npos && filters.at(z) != "") {
+                if (found_position != std::string::npos && !filters.at(z).empty()) {
                     found = true;
 
                     input_filter_index = z;
@@ -82,86 +81,86 @@ void rpkg_function::extract_from_rpkg(rpkg_extraction_vars& rpkg_vars) {
                 }
             }
 
-            if (found || rpkg_vars.filter.empty()) {
-                if (!filters.empty()) {
-                    extracted.at(input_filter_index) = true;
-                }
+            if (!found && !rpkg_vars.filter.empty()) continue;
 
-                uint64_t hash_size;
+            if (!filters.empty()) {
+                extracted.at(input_filter_index) = true;
+            }
 
-                if (rpkgs.at(i).hash.at(j).data.lz4ed) {
-                    hash_size = rpkgs.at(i).hash.at(j).data.header.data_size;
+            uint64_t hash_size;
 
-                    if (rpkgs.at(i).hash.at(j).data.xored) {
-                        hash_size &= 0x3FFFFFFF;
-                    }
-                } else {
-                    hash_size = rpkgs.at(i).hash.at(j).data.resource.size_final;
-                }
-
-                std::vector<char> input_data(hash_size, 0);
-
-                std::ifstream file = std::ifstream(rpkg_vars.input_path, std::ifstream::binary);
-
-                if (!file.good()) {
-                    LOG_AND_EXIT("Error: RPKG file " + rpkg_vars.input_path + " could not be read.");
-                }
-
-                file.seekg(rpkgs.at(i).hash.at(j).data.header.data_offset, file.beg);
-                file.read(input_data.data(), hash_size);
+            if (rpkgs.at(i).hash.at(j).data.lz4ed) {
+                hash_size = rpkgs.at(i).hash.at(j).data.header.data_size;
 
                 if (rpkgs.at(i).hash.at(j).data.xored) {
-                    crypto::xor_data(input_data.data(), (uint32_t) hash_size);
+                    hash_size &= 0x3FFFFFFF;
+                }
+            } else {
+                hash_size = rpkgs.at(i).hash.at(j).data.resource.size_final;
+            }
+
+            std::vector<char> input_data(hash_size, 0);
+
+            std::ifstream file = std::ifstream(rpkg_vars.input_path, std::ifstream::binary);
+
+            if (!file.good()) {
+                LOG_AND_EXIT("Error: RPKG file " + rpkg_vars.input_path + " could not be read.");
+            }
+
+            file.seekg(rpkgs.at(i).hash.at(j).data.header.data_offset, file.beg);
+            file.read(input_data.data(), hash_size);
+
+            if (rpkgs.at(i).hash.at(j).data.xored) {
+                crypto::xor_data(input_data.data(), (uint32_t) hash_size);
+            }
+
+            final_path = hash_file_path + "\\" + rpkgs.at(i).hash.at(j).hash_resource_type;
+
+            if (!rpkg_vars.search_mode) {
+                file::create_directories(final_path);
+            }
+
+            std::vector<char>* output_data;
+            uint64_t output_data_size;
+
+            uint32_t decompressed_size = rpkgs.at(i).hash.at(j).data.resource.size_final;
+            std::vector<char> lz4_output_data(decompressed_size, 0);
+
+            if (rpkgs.at(i).hash.at(j).data.lz4ed) {
+                LZ4_decompress_safe(input_data.data(), lz4_output_data.data(), (int) hash_size, decompressed_size);
+
+                output_data = &lz4_output_data;
+                output_data_size = decompressed_size;
+            } else {
+                output_data = &input_data;
+                output_data_size = hash_size;
+            }
+
+            final_path += "\\" + hash_file_name;
+
+            if (!rpkg_vars.search_mode) {
+                if (rpkg_vars.ores_mode) {
+                    final_path = rpkg_vars.ores_path;
                 }
 
-                final_path = hash_file_path + "\\" + rpkgs.at(i).hash.at(j).hash_resource_type;
+                std::ofstream output_file = std::ofstream(final_path, std::ofstream::binary);
 
-                if (!rpkg_vars.search_mode) {
-                    file::create_directories(final_path);
+                if (!output_file.good()) {
+                    LOG_AND_EXIT("Error: Hash file " + final_path + " could not be created.");
                 }
 
-                std::vector<char>* output_data;
-                uint64_t output_data_size;
+                output_file.write((*output_data).data(), output_data_size);
 
-                uint32_t decompressed_size = rpkgs.at(i).hash.at(j).data.resource.size_final;
-                std::vector<char> lz4_output_data(decompressed_size, 0);
+                output_file.close();
+            }
 
-                if (rpkgs.at(i).hash.at(j).data.lz4ed) {
-                    LZ4_decompress_safe(input_data.data(), lz4_output_data.data(), (int) hash_size, decompressed_size);
+            if (rpkg_vars.search_mode) {
+                rpkg_function::search_hash_data(rpkg_vars.search_type, rpkg_vars.search, *output_data,
+                                                hash_file_name);
+            }
 
-                    output_data = &lz4_output_data;
-                    output_data_size = decompressed_size;
-                } else {
-                    output_data = &input_data;
-                    output_data_size = hash_size;
-                }
-
-                final_path += "\\" + hash_file_name;
-
-                if (!rpkg_vars.search_mode) {
-                    if (rpkg_vars.ores_mode) {
-                        final_path = rpkg_vars.ores_path;
-                    }
-
-                    std::ofstream output_file = std::ofstream(final_path, std::ofstream::binary);
-
-                    if (!output_file.good()) {
-                        LOG_AND_EXIT("Error: Hash file " + final_path + " could not be created.");
-                    }
-
-                    output_file.write((*output_data).data(), output_data_size);
-
-                    output_file.close();
-                }
-
-                if (rpkg_vars.search_mode) {
-                    rpkg_function::search_hash_data(rpkg_vars.search_type, rpkg_vars.search, *output_data,
-                                                    hash_file_name);
-                }
-
-                if (!rpkg_vars.search_mode && !rpkg_vars.ores_mode) {
-                    rpkg_function::extract_hash_meta(i, j, final_path);
-                }
+            if (!rpkg_vars.search_mode && !rpkg_vars.ores_mode) {
+                rpkg_function::extract_hash_meta(i, j, final_path);
             }
         }
 

--- a/src/extract_from_rpkgs.cpp
+++ b/src/extract_from_rpkgs.cpp
@@ -6,7 +6,6 @@
 #include "crypto.h"
 #include "thirdparty/lz4/lz4.h"
 #include <fstream>
-#include <regex>
 #include <sstream>
 #include <filesystem>
 
@@ -109,7 +108,7 @@ void rpkg_function::extract_from_rpkgs(rpkg_extraction_vars& rpkg_vars) {
                     LOG_AND_EXIT("Error: RPKG file " + rpkg_vars.input_path + " could not be read.");
                 }
 
-                file.seekg(rpkgs.at(i).hash.at(j).data.header.data_offset, file.beg);
+                file.seekg(rpkgs.at(i).hash.at(j).data.header.data_offset, std::ifstream::beg);
                 file.read(input_data.data(), hash_size);
 
                 if (rpkgs.at(i).hash.at(j).data.xored) {

--- a/src/extract_gfxf_from.cpp
+++ b/src/extract_gfxf_from.cpp
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <fstream>
 
+constexpr char bin1_header[] = {0x42, 0x49, 0x4E, 0x31, 0x00, 0x08, 0x01, 0x00};
+
 void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filter, std::string& output_path) {
     task_single_status = TASK_EXECUTING;
     task_multiple_status = TASK_EXECUTING;
@@ -125,9 +127,9 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
     std::vector<std::string> not_found_in;
 
     for (uint64_t z = 0; z < filters.size(); z++) {
-        found_in.push_back("");
+        found_in.emplace_back("");
 
-        not_found_in.push_back("");
+        not_found_in.emplace_back("");
     }
 
     for (uint64_t i = 0; i < rpkgs.size(); i++) {
@@ -216,12 +218,10 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
 
                         std::vector<char> gfxf_meta_data;
 
-                        char bin1_header[] = {0x42, 0x49, 0x4E, 0x31, 0x00, 0x08, 0x01, 0x00};
-
                         bool is_valid_bin1_header = true;
 
                         for (uint64_t k = 0; k < sizeof(bin1_header); k++) {
-                            if (gfxf_data->data()[k] != bin1_header[k]) {
+                            if ((*gfxf_data)[k] != bin1_header[k]) {
                                 is_valid_bin1_header = false;
                             }
 
@@ -246,7 +246,7 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
                             uint32_t dds_data_offset_start = 0;
                             uint32_t dds_data_offset_end = 0;
 
-                            std::memcpy(&input, &gfxf_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&input, &(*gfxf_data)[position], BYTES4);
                             position += 0x4;
 
                             char4[0] = input[3];
@@ -256,29 +256,29 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
 
                             //std::cout << char4 << std::endl;
 
-                            std::memcpy(&gfxf_file_length, &char4[0], sizeof(bytes4));
+                            std::memcpy(&gfxf_file_length, &char4[0], BYTES4);
 
                             //std::cout << std::hex << gfxf_file_length << std::endl;
 
-                            std::memcpy(&bytes4, &gfxf_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&bytes4, &(*gfxf_data)[position], BYTES4);
                             position += 0x4;
 
-                            std::memcpy(&gfx_file_offset, &gfxf_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&gfx_file_offset, &(*gfxf_data)[position], BYTES4);
                             gfx_file_offset += 0x10;
                             position += 0x4;
 
-                            std::memcpy(&bytes4, &gfxf_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&bytes4, &(*gfxf_data)[position], BYTES4);
                             position += 0x4;
 
-                            std::memcpy(&gfx_file_length, &gfxf_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&gfx_file_length, &(*gfxf_data)[position], BYTES4);
                             position += 0x4;
 
-                            std::memcpy(&bytes4, &gfxf_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&bytes4, &(*gfxf_data)[position], BYTES4);
                             position += 0x4;
 
                             //std::cout << rpkgs.at(i).rpkg_file_name << "," << hash_file_name << std::endl;
 
-                            std::memcpy(&bytes8, &gfxf_data->data()[position], sizeof(bytes8));
+                            std::memcpy(&bytes8, &(*gfxf_data)[position], BYTES8);
 
                             if (bytes8 != 0xFFFFFFFFFFFFFFFF) {
                                 gfxf_contains_dds = true;
@@ -291,32 +291,32 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
                             if (gfxf_contains_dds) {
                                 //std::cout << "GFXF contains DDS files." << std::endl;
 
-                                std::memcpy(&dds_names_offset_start, &gfxf_data->data()[position], sizeof(bytes4));
+                                std::memcpy(&dds_names_offset_start, &(*gfxf_data)[position], BYTES4);
                                 dds_names_offset_start += 0x10;
                                 position += 0x8;
 
-                                std::memcpy(&dds_names_offset_end, &gfxf_data->data()[position], sizeof(bytes4));
+                                std::memcpy(&dds_names_offset_end, &(*gfxf_data)[position], BYTES4);
                                 dds_names_offset_end += 0x10;
                                 position += 0x8;
 
-                                std::memcpy(&dds_names_offset_end, &gfxf_data->data()[position], sizeof(bytes4));
+                                std::memcpy(&dds_names_offset_end, &(*gfxf_data)[position], BYTES4);
                                 dds_names_offset_end += 0x10;
                                 position += 0x8;
 
-                                std::memcpy(&dds_data_offset_start, &gfxf_data->data()[position], sizeof(bytes4));
+                                std::memcpy(&dds_data_offset_start, &(*gfxf_data)[position], BYTES4);
                                 dds_data_offset_start += 0x10;
                                 position += 0x8;
 
-                                std::memcpy(&dds_data_offset_end, &gfxf_data->data()[position], sizeof(bytes4));
+                                std::memcpy(&dds_data_offset_end, &(*gfxf_data)[position], BYTES4);
                                 dds_data_offset_end += 0x10;
                                 position += 0x8;
 
-                                std::memcpy(&dds_data_offset_end, &gfxf_data->data()[position], sizeof(bytes4));
+                                std::memcpy(&dds_data_offset_end, &(*gfxf_data)[position], BYTES4);
                                 dds_data_offset_end += 0x10;
                                 position += 0x8;
                             }
 
-                            std::memcpy(&bytes4, &gfxf_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&bytes4, &(*gfxf_data)[position], BYTES4);
                             position += 0x4;
 
                             //std::cout << bytes4 << std::endl;
@@ -329,7 +329,7 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
                             std::vector<char> gfx_data;
 
                             for (uint64_t k = 0; k < gfx_file_length; k++) {
-                                gfx_data.push_back(gfxf_data->data()[position]);
+                                gfx_data.push_back((*gfxf_data)[position]);
 
                                 position++;
                             }
@@ -360,10 +360,10 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
                                     position++;
                                 }
 
-                                std::memcpy(&dds_names_count, &gfxf_data->data()[position], sizeof(bytes4));
+                                std::memcpy(&dds_names_count, &(*gfxf_data)[position], BYTES4);
 
-                                for (uint64_t k = 0; k < sizeof(bytes4); k++) {
-                                    gfxf_meta_data.push_back(gfxf_data->data()[position + k]);
+                                for (uint64_t k = 0; k < BYTES4; k++) {
+                                    gfxf_meta_data.push_back((*gfxf_data)[position + k]);
                                 }
 
                                 position += 0x4;
@@ -374,12 +374,12 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
                                     uint32_t dds_name_length = 0;
                                     uint32_t dds_name_offset = 0;
 
-                                    std::memcpy(&dds_name_length, &gfxf_data->data()[position], sizeof(bytes4));
+                                    std::memcpy(&dds_name_length, &(*gfxf_data)[position], BYTES4);
                                     dds_name_length &= 0xBFFFFFFF;
 
-                                    std::memcpy(&input, &dds_name_length, sizeof(bytes4));
+                                    std::memcpy(&input, &dds_name_length, BYTES4);
 
-                                    for (uint64_t k = 0; k < sizeof(bytes4); k++) {
+                                    for (uint64_t k = 0; k < BYTES4; k++) {
                                         gfxf_meta_data.push_back(input[k]);
                                     }
 
@@ -387,20 +387,20 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
 
                                     //std::cout << std::hex << dds_name_length << std::endl;
 
-                                    std::memcpy(&dds_name_offset, &gfxf_data->data()[position], sizeof(bytes4));
+                                    std::memcpy(&dds_name_offset, &(*gfxf_data)[position], BYTES4);
                                     dds_name_offset += 0x10;
                                     position += 0x8;
 
                                     //std::cout << std::hex << dds_name_offset << std::endl;
 
-                                    std::memcpy(&input, &gfxf_data->data()[dds_name_offset],
+                                    std::memcpy(&input, &(*gfxf_data)[dds_name_offset],
                                                 (static_cast<uint64_t>(dds_name_length) + static_cast<uint64_t>(1)));
 
                                     for (uint64_t k = 0; k < static_cast<uint64_t>(dds_name_length); k++) {
-                                        gfxf_meta_data.push_back(gfxf_data->data()[dds_name_offset + k]);
+                                        gfxf_meta_data.push_back((*gfxf_data)[dds_name_offset + k]);
                                     }
 
-                                    dds_names.push_back(std::string(input));
+                                    dds_names.emplace_back(input);
 
                                     //std::cout << dds_names.back() << std::endl;
                                 }
@@ -412,18 +412,18 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
                                     uint32_t temp_dds_data_offset_start = 0;
                                     uint32_t temp_dds_data_offset_end = 0;
 
-                                    std::memcpy(&temp_dds_data_offset_start, &gfxf_data->data()[position],
-                                                sizeof(bytes4));
+                                    std::memcpy(&temp_dds_data_offset_start, &(*gfxf_data)[position],
+                                                BYTES4);
                                     temp_dds_data_offset_start += 0x10;
                                     position += 0x8;
 
-                                    std::memcpy(&temp_dds_data_offset_end, &gfxf_data->data()[position],
-                                                sizeof(bytes4));
+                                    std::memcpy(&temp_dds_data_offset_end, &(*gfxf_data)[position],
+                                                BYTES4);
                                     temp_dds_data_offset_end += 0x10;
                                     position += 0x8;
 
-                                    std::memcpy(&temp_dds_data_offset_end, &gfxf_data->data()[position],
-                                                sizeof(bytes4));
+                                    std::memcpy(&temp_dds_data_offset_end, &(*gfxf_data)[position],
+                                                BYTES4);
                                     temp_dds_data_offset_end += 0x10;
                                     position += 0x8;
 
@@ -441,7 +441,7 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
                                                      " could not be created.");
                                     }
 
-                                    output_file.write(&gfxf_data->data()[temp_dds_data_offset_start],
+                                    output_file.write(&(*gfxf_data)[temp_dds_data_offset_start],
                                                       temp_dds_data_length);
 
                                     output_file.close();
@@ -469,7 +469,7 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
 
                             if ((decompressed_size - position) > 0) {
                                 for (uint64_t k = 0; k < (decompressed_size - position); k++) {
-                                    gfxf_meta_data.push_back(gfxf_data->data()[position + k]);
+                                    gfxf_meta_data.push_back((*gfxf_data)[position + k]);
                                 }
                             }
 
@@ -488,18 +488,18 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
             }
         }
 
-        if (filter == "")
+        if (filter.empty())
             continue;
 
         for (uint64_t z = 0; z < filters.size(); z++) {
             if (extracted.at(z)) {
-                if (found_in.at(z) == "") {
+                if (found_in.at(z).empty()) {
                     found_in.at(z).append(rpkgs.at(i).rpkg_file_name);
                 } else {
                     found_in.at(z).append(", " + rpkgs.at(i).rpkg_file_name);
                 }
             } else {
-                if (not_found_in.at(z) == "") {
+                if (not_found_in.at(z).empty()) {
                     not_found_in.at(z).append(rpkgs.at(i).rpkg_file_name);
                 } else {
                     not_found_in.at(z).append(", " + rpkgs.at(i).rpkg_file_name);
@@ -519,7 +519,7 @@ void rpkg_function::extract_gfxf_from(std::string& input_path, std::string& filt
 
     percent_progress = static_cast<uint32_t>(100);
 
-    if (filter != "") {
+    if (!filter.empty()) {
         for (uint64_t z = 0; z < filters.size(); z++) {
             LOG(std::endl << "\"" << filters.at(z) << "\" was found in and extracted from: " << found_in.at(z));
 

--- a/src/extract_locr_to_json_from.cpp
+++ b/src/extract_locr_to_json_from.cpp
@@ -192,13 +192,13 @@ void rpkg_function::extract_locr_to_json_from(std::string& input_path, std::stri
                     bool isLOCRv2 = false;
                     bool symKey = false;
 
-                    if ((unsigned int) locr_data->data()[0] == 0 || (unsigned int) locr_data->data()[0] == 1) {
+                    if ((unsigned int) (*locr_data)[0] == 0 || (unsigned int) (*locr_data)[0] == 1) {
                         position += 1;
-                        std::memcpy(&number_of_languages, &locr_data->data()[position], sizeof(bytes4));
+                        std::memcpy(&number_of_languages, &(*locr_data)[position], BYTES4);
                         number_of_languages = (number_of_languages - 1) / 4;
                         isLOCRv2 = true;
                     } else {
-                        std::memcpy(&number_of_languages, &locr_data->data()[position], sizeof(bytes4));
+                        std::memcpy(&number_of_languages, &(*locr_data)[position], BYTES4);
                         number_of_languages = (number_of_languages) / 4;
                     }
 
@@ -214,44 +214,44 @@ void rpkg_function::extract_locr_to_json_from(std::string& input_path, std::stri
 
                     // Quick fix for New Hitman 3 LOCR
                     if (number_of_languages == 9 && isLOCRv2) {
-                        languages.push_back("xx");
-                        languages.push_back("en");
-                        languages.push_back("fr");
-                        languages.push_back("it");
-                        languages.push_back("de");
-                        languages.push_back("es");
-                        languages.push_back("ru");
-                        languages.push_back("cn");
-                        languages.push_back("tc");
+                        languages.emplace_back("xx");
+                        languages.emplace_back("en");
+                        languages.emplace_back("fr");
+                        languages.emplace_back("it");
+                        languages.emplace_back("de");
+                        languages.emplace_back("es");
+                        languages.emplace_back("ru");
+                        languages.emplace_back("cn");
+                        languages.emplace_back("tc");
                     } else if (number_of_languages == 10 && isLOCRv2) {
-                        languages.push_back("xx");
-                        languages.push_back("en");
-                        languages.push_back("fr");
-                        languages.push_back("it");
-                        languages.push_back("de");
-                        languages.push_back("es");
-                        languages.push_back("ru");
-                        languages.push_back("cn");
-                        languages.push_back("tc");
-                        languages.push_back("jp");
+                        languages.emplace_back("xx");
+                        languages.emplace_back("en");
+                        languages.emplace_back("fr");
+                        languages.emplace_back("it");
+                        languages.emplace_back("de");
+                        languages.emplace_back("es");
+                        languages.emplace_back("ru");
+                        languages.emplace_back("cn");
+                        languages.emplace_back("tc");
+                        languages.emplace_back("jp");
                     } else {
-                        languages.push_back("xx");
-                        languages.push_back("en");
-                        languages.push_back("fr");
-                        languages.push_back("it");
-                        languages.push_back("de");
-                        languages.push_back("es");
-                        languages.push_back("ru");
-                        languages.push_back("mx");
-                        languages.push_back("br");
-                        languages.push_back("pl");
-                        languages.push_back("cn");
-                        languages.push_back("jp");
-                        languages.push_back("tc");
+                        languages.emplace_back("xx");
+                        languages.emplace_back("en");
+                        languages.emplace_back("fr");
+                        languages.emplace_back("it");
+                        languages.emplace_back("de");
+                        languages.emplace_back("es");
+                        languages.emplace_back("ru");
+                        languages.emplace_back("mx");
+                        languages.emplace_back("br");
+                        languages.emplace_back("pl");
+                        languages.emplace_back("cn");
+                        languages.emplace_back("jp");
+                        languages.emplace_back("tc");
                     }
 
                     for (uint64_t k = 0; k < number_of_languages; k++) {
-                        std::memcpy(&bytes4, &locr_data->data()[position], sizeof(bytes4));
+                        std::memcpy(&bytes4, &(*locr_data)[position], BYTES4);
                         position += 4;
 
                         language_offsets.push_back(bytes4);
@@ -259,14 +259,14 @@ void rpkg_function::extract_locr_to_json_from(std::string& input_path, std::stri
 
                     for (uint64_t k = 0; k < (number_of_languages * (uint64_t) 0x4 +
                                               (isLOCRv2 ? (uint64_t) 0x1 : (uint64_t) 0x0)); k++) {
-                        json_meta_data.push_back(locr_data->data()[k]);
+                        json_meta_data.push_back((*locr_data)[k]);
                     }
 
                     for (uint64_t k = 0; k < number_of_languages; k++) {
                         if (language_offsets.at(k) == 0xFFFFFFFF)
                             continue;
 
-                        std::memcpy(&bytes4, &locr_data->data()[position], sizeof(bytes4));
+                        std::memcpy(&bytes4, &(*locr_data)[position], BYTES4);
                         position += 4;
 
                         language_string_count.push_back(bytes4);
@@ -286,18 +286,18 @@ void rpkg_function::extract_locr_to_json_from(std::string& input_path, std::stri
                         for (uint64_t l = 0; l < language_string_count.back(); l++) {
                             std::vector<char> temp_string;
 
-                            std::memcpy(&bytes4, &locr_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&bytes4, &(*locr_data)[position], BYTES4);
                             position += 4;
 
                             temp_language_string_hash.push_back(bytes4);
 
-                            std::memcpy(&bytes4, &locr_data->data()[position], sizeof(bytes4));
+                            std::memcpy(&bytes4, &(*locr_data)[position], BYTES4);
                             position += 4;
 
                             temp_language_string_length.push_back(bytes4);
 
                             for (uint64_t m = 0; m < temp_language_string_length.back(); m++) {
-                                temp_string.push_back(locr_data->data()[position]);
+                                temp_string.push_back((*locr_data)[position]);
                                 position += 1;
                             }
 
@@ -338,10 +338,10 @@ void rpkg_function::extract_locr_to_json_from(std::string& input_path, std::stri
                                                 data + 1, sizeof(uint32_t));
                                 }
 
-                                uint32_t last_zero_position = (uint32_t) temp_string.size();
+                                auto last_zero_position = (uint32_t) temp_string.size();
 
                                 if (!temp_string.empty()) {
-                                    uint32_t m = (uint32_t) (temp_string.size() - 1);
+                                    auto m = (uint32_t) (temp_string.size() - 1);
 
                                     while (m >= 0) {
                                         if (temp_string.at(m) != 0) {

--- a/src/extract_material_to_json.cpp
+++ b/src/extract_material_to_json.cpp
@@ -5,7 +5,6 @@
 #include "util.h"
 #include "material.h"
 #include <chrono>
-#include <filesystem>
 #include <iostream>
 
 void rpkg_function::extract_material_to_json(std::string& input_path, std::string& filter, std::string& output_path) {
@@ -14,69 +13,69 @@ void rpkg_function::extract_material_to_json(std::string& input_path, std::strin
 
     std::string input_rpkg_folder_path = file::parse_input_folder_path(input_path);
 
-    if (file::path_exists(input_rpkg_folder_path)) {
-        log_output = false;
+    if (!file::path_exists(input_rpkg_folder_path)) {
+        LOG_AND_EXIT("Error: The RPKG folder " + input_path + " does not exist.");
+    }
 
-        if (!hash_list_loaded) {
-            LOG("Loading Hash List...");
-            generic_function::load_hash_list(false);
-            LOG("Loading Hash List: Done");
-        }
+    log_output = false;
 
-        rpkg_function::import_rpkg_files_in_folder(input_rpkg_folder_path);
+    if (!hash_list_loaded) {
+        LOG("Loading Hash List...");
+        generic_function::load_hash_list(false);
+        LOG("Loading Hash List: Done");
+    }
 
-        std::vector<std::string> filters = util::parse_input_filter(filter);
+    rpkg_function::import_rpkg_files_in_folder(input_rpkg_folder_path);
 
-        for (uint64_t f = 0; f < filters.size(); f++) {
-            uint64_t mati_hash_value = std::strtoull(filters.at(f).c_str(), nullptr, 16);
+    std::vector<std::string> filters = util::parse_input_filter(filter);
 
-            uint32_t rpkg_index = rpkg_function::get_latest_hash(mati_hash_value);
+    for (const auto & filter : filters) {
+        const uint64_t mati_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
-            if (rpkg_index != UINT32_MAX) {
-                std::unordered_map<uint64_t, uint64_t>::iterator it = rpkgs.at(rpkg_index).hash_map.find(
-                        mati_hash_value);
+        const uint32_t rpkg_index = rpkg_function::get_latest_hash(mati_hash_value);
 
-                if (it != rpkgs.at(rpkg_index).hash_map.end()) {
-                    timing_string = "Converting: " +
-                                    util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) +
-                                    "." + rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type +
-                                    " to Material Entity (MATI/MATT/MATB) JSON";
+        if (rpkg_index != UINT32_MAX) {
+            auto it = rpkgs.at(rpkg_index).hash_map.find(
+                    mati_hash_value);
 
-                    material temp_material(rpkg_index, it->second);
+            if (it != rpkgs.at(rpkg_index).hash_map.end()) {
+                timing_string = "Converting: " +
+                                util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) +
+                                "." + rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type +
+                                " to Material Entity (MATI/MATT/MATB) JSON";
 
-                    std::string temp_output_path = "";
-                    bool output_path_is_dir = false;
+                material temp_material(rpkg_index, it->second);
 
-                    if (output_path.length() > 5) {
-                        if (util::to_lower_case(output_path).substr(output_path.length() - 5) == ".json") {
-                            temp_output_path = output_path;
-                        } else {
-                            output_path_is_dir = true;
-                        }
+                std::string temp_output_path = "";
+                bool output_path_is_dir = false;
+
+                if (output_path.length() > 5) {
+                    if (util::to_lower_case(output_path).substr(output_path.length() - 5) == ".json") {
+                        temp_output_path = output_path;
                     } else {
                         output_path_is_dir = true;
                     }
+                } else {
+                    output_path_is_dir = true;
+                }
 
-                    if (output_path_is_dir) {
-                        if (output_path != "") {
-                            file::create_directories(output_path);
-                        }
-
-                        temp_output_path = file::output_path_append(filters.at(f) + ".material.json", output_path);
+                if (output_path_is_dir) {
+                    if (!output_path.empty()) {
+                        file::create_directories(output_path);
                     }
 
-                    temp_material.generate_json();
-
-                    temp_material.write_json_to_file(temp_output_path);
+                    temp_output_path = file::output_path_append(filter + ".material.json", output_path);
                 }
+
+                temp_material.generate_json();
+
+                temp_material.write_json_to_file(temp_output_path);
             }
         }
-
-        log_output = true;
-
-        task_single_status = TASK_SUCCESSFUL;
-        task_multiple_status = TASK_SUCCESSFUL;
-    } else {
-        LOG_AND_EXIT("Error: The RPKG folder " + input_path + " does not exist.");
     }
+
+    log_output = true;
+
+    task_single_status = TASK_SUCCESSFUL;
+    task_multiple_status = TASK_SUCCESSFUL;
 }

--- a/src/extract_mati_to_json.cpp
+++ b/src/extract_mati_to_json.cpp
@@ -31,9 +31,9 @@ void rpkg_function::extract_mati_to_json(std::string& input_path, const std::str
 
     rpkg_function::import_rpkg(input_path, true);
 
-    std::vector<std::string> filters = util::parse_input_filter(filter);
+    const std::vector<std::string> filters = util::parse_input_filter(filter);
 
-    for (auto& filter : filters) {
+    for (const auto& filter : filters) {
         uint64_t text_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
         for (uint64_t i = 0; i < rpkgs.size(); i++) {

--- a/src/extract_mrtr_to_json.cpp
+++ b/src/extract_mrtr_to_json.cpp
@@ -3,7 +3,6 @@
 #include "global.h"
 #include "util.h"
 #include "mrtr.h"
-#include <unordered_map>
 #include <chrono>
 #include <sstream>
 #include <filesystem>
@@ -27,8 +26,8 @@ void rpkg_function::extract_mrtr_to_json(std::string& input_path, const std::str
 
     const std::vector<std::string> filters = util::parse_input_filter(filter);
 
-    for (auto& filter : filters) {
-        uint64_t text_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
+    for (const auto& filter : filters) {
+        const uint64_t text_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
         for (uint64_t i = 0; i < rpkgs.size(); i++) {
             uint64_t rpkg_index = i;
@@ -36,7 +35,7 @@ void rpkg_function::extract_mrtr_to_json(std::string& input_path, const std::str
             if (rpkgs.at(i).rpkg_file_path != input_path)
                 continue;
 
-            std::unordered_map<uint64_t, uint64_t>::iterator it = rpkgs.at(rpkg_index).hash_map.find(text_hash_value);
+            auto it = rpkgs.at(rpkg_index).hash_map.find(text_hash_value);
 
             if (it == rpkgs.at(rpkg_index).hash_map.end())
                 continue;

--- a/src/extract_ores_from.cpp
+++ b/src/extract_ores_from.cpp
@@ -110,7 +110,7 @@ void rpkg_function::extract_ores_from(std::string& input_path, std::string& filt
 
                 std::string hash_string = util::uint64_t_to_hex_string(ores_entry.second);
 
-                if (!extract_single_hash || (extract_single_hash && filter == hash_string)) {
+                if (!extract_single_hash || filter == hash_string) {
                     for (uint64_t i = 0; i < rpkgs.size(); i++) {
                         uint64_t rpkg_index2 = i;
 

--- a/src/extract_prel_from.cpp
+++ b/src/extract_prel_from.cpp
@@ -110,10 +110,10 @@ void rpkg_function::extract_prel_refs(std::string& input_path) {
                 uint64_t master_hash_depends_count = 0;
                 std::vector<uint64_t> master_hash_depends;
 
-                std::memcpy(&master_hash_value, &prel_data->data()[position], sizeof(uint64_t));
+                std::memcpy(&master_hash_value, &(*prel_data)[position], sizeof(uint64_t));
                 position += 0x8;
 
-                std::memcpy(&master_hash_depends_count, &prel_data->data()[position], sizeof(uint64_t));
+                std::memcpy(&master_hash_depends_count, &(*prel_data)[position], sizeof(uint64_t));
                 position += 0x8;
 
                 std::cout << std::endl << std::endl << "PREL file name: " << hash_file_name << std::endl;
@@ -133,7 +133,7 @@ void rpkg_function::extract_prel_refs(std::string& input_path) {
                 for (uint64_t k = 0; k < master_hash_depends_count; k++) {
                     uint64_t temp_master_hash_depend_hash_value = 0;
 
-                    std::memcpy(&temp_master_hash_depend_hash_value, &prel_data->data()[position], sizeof(uint64_t));
+                    std::memcpy(&temp_master_hash_depend_hash_value, &(*prel_data)[position], sizeof(uint64_t));
                     position += 0x8;
 
                     master_hash_depends.push_back(temp_master_hash_depend_hash_value);

--- a/src/extract_prim_from.cpp
+++ b/src/extract_prim_from.cpp
@@ -55,7 +55,7 @@ void rpkg_function::extract_prim_from(std::string& input_path, std::string filte
 
             auto it = rpkgs.at(rpkg_index).hash_map.find(temp_hash_value);
 
-            if (!(it != rpkgs.at(rpkg_index).hash_map.end()))
+            if (it == rpkgs.at(rpkg_index).hash_map.end())
                 continue;
 
             if (gui_control == ABORT_CURRENT_TASK) {

--- a/src/extract_prim_model_from.cpp
+++ b/src/extract_prim_model_from.cpp
@@ -40,7 +40,7 @@ void rpkg_function::extract_prim_model_from(std::string& input_path, std::string
 
     std::vector<std::string> filters = util::parse_input_filter(std::move(filter));
 
-    for (auto& filter : filters) {
+    for (const auto& filter : filters) {
         uint64_t temp_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
         for (uint64_t i = 0; i < rpkgs.size(); i++) {
@@ -72,12 +72,12 @@ void rpkg_function::extract_prim_model_from(std::string& input_path, std::string
                     util::replace_all_string_in_string(output_path, to_replace, replace_with);
                 }
 
-                std::string prim_output_path = file::output_path_append(
+                const std::string prim_output_path = file::output_path_append(
                         util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) + "." +
                         rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type + "\\PRIM\\" +
                         rpkgs.at(rpkg_index).rpkg_file_name, output_path);
 
-                std::string text_output_path = file::output_path_append(
+                const std::string text_output_path = file::output_path_append(
                         util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) + "." +
                         rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type, output_path);
 
@@ -91,7 +91,7 @@ void rpkg_function::extract_prim_model_from(std::string& input_path, std::string
 
                 prim_asset_file_names.push_back(asset_file_name);
 
-                std::string meta_path = prim_output_path + "\\" + "metas";
+                const std::string meta_path = prim_output_path + "\\" + "metas";
 
                 file::create_directories(meta_path);
 

--- a/src/extract_prim_textured_from.cpp
+++ b/src/extract_prim_textured_from.cpp
@@ -7,7 +7,6 @@
 #include "util.h"
 #include "text.h"
 #include "generic_function.h"
-#include <unordered_map>
 #include <chrono>
 #include <sstream>
 #include <filesystem>
@@ -45,11 +44,7 @@ void rpkg_function::extract_prim_textured_from(std::string& input_path, std::str
 
     //LOG("\r" + ss.str() + std::string((80 - ss.str().length()), ' '));
 
-    if (!hash_list_loaded) {
-        LOG("Loading Hash List...");
-        generic_function::load_hash_list(true);
-        LOG("Loading Hash List: Done");
-    }
+    force_load_hash_list();
 
     //std::vector<std::string>().swap(prim_asset_file_names);
 
@@ -75,7 +70,7 @@ void rpkg_function::extract_prim_textured_from(std::string& input_path, std::str
 
         prim temp_prim(rpkg_index, it->second);
 
-        if (temp_prim.asset3ds_data.vertexes.size() <= 0 || !temp_prim.success)
+        if (temp_prim.asset3ds_data.vertexes.empty() || !temp_prim.success)
             continue;
 
         for (auto& color : temp_prim.asset3ds_data.colors) {
@@ -135,8 +130,6 @@ void rpkg_function::extract_prim_textured_from(std::string& input_path, std::str
             mati temp_mati(temp_rpkg_index, it2->second);
 
             temp_mati.map_textures();
-
-            std::unordered_map<uint64_t, uint64_t>::iterator it3;
 
             if (temp_mati.has_diffuse_texture) {
                 uint32_t temp_rpkg_index2 = rpkg_function::get_latest_hash(temp_mati.diffuse_texture_hash);

--- a/src/extract_sdef_to_json.cpp
+++ b/src/extract_sdef_to_json.cpp
@@ -33,7 +33,7 @@ void rpkg_function::extract_sdef_to_json(std::string& input_path, const std::str
 
     const std::vector<std::string> filters = util::parse_input_filter(filter);
 
-    for (auto& filter : filters) {
+    for (const auto& filter : filters) {
         uint64_t text_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
         for (uint64_t i = 0; i < rpkgs.size(); i++) {

--- a/src/extract_text_from.cpp
+++ b/src/extract_text_from.cpp
@@ -33,10 +33,6 @@ rpkg_function::extract_text_from(std::string& input_path, const std::string& fil
 
     ss << "Scanning folder: Done";
 
-    //LOG("\r" + ss.str() + std::string((80 - ss.str().length()), ' '));
-
-    //std::vector<std::string>().swap(prim_asset_file_names);
-
     const std::vector<std::string> filters = util::parse_input_filter(filter);
 
     for (const auto& filter : filters) {
@@ -64,11 +60,11 @@ rpkg_function::extract_text_from(std::string& input_path, const std::string& fil
 
             file::create_directories(text_output_dir);
 
-            std::string tga_path = text_output_dir + "\\" +
+            const std::string tga_path = text_output_dir + "\\" +
                                    util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(it->second).hash_value) +
                                    "." + rpkgs.at(rpkg_index).hash.at(it->second).hash_resource_type + ".tga";
 
-            std::string meta_path = text_output_dir + "\\" + "metas";
+            const std::string meta_path = text_output_dir + "\\" + "metas";
 
             file::create_directories(meta_path);
 

--- a/src/extract_to_rt_json.cpp
+++ b/src/extract_to_rt_json.cpp
@@ -7,7 +7,6 @@
 #include "thirdparty/rapidjson/document.h"
 #include "thirdparty/rapidjson/prettywriter.h"
 #include "thirdparty/rapidjson/stringbuffer.h"
-#include <unordered_map>
 #include <sstream>
 #include <fstream>
 #include <filesystem>
@@ -18,6 +17,13 @@
 #pragma comment(lib, "../thirdparty/zhmtools/ResourceLib_HM2016.lib")
 #pragma comment(lib, "../thirdparty/zhmtools/ResourceLib_HM2.lib")
 #pragma comment(lib, "../thirdparty/zhmtools/ResourceLib_HM3.lib")
+
+const std::vector<std::string> hm2016_valid_resources = {"TEMP", "AIRG", "TBLU", "CRMD", "ATMD", "CBLU", "CPPT", "DSWB",
+                                                         "GFXF", "GIDX", "VIDB", "WSGB"};
+const std::vector<std::string> hm2_valid_resources = {"TEMP", "AIRG", "TBLU", "CRMD", "ATMD", "CBLU", "CPPT", "DSWB",
+                                                      "ECPB", "GFXF", "GIDX", "VIDB", "WSGB"};
+const std::vector<std::string> hm3_valid_resources = {"TEMP", "AIRG", "TBLU", "CRMD", "ATMD", "CBLU", "CPPT", "DSWB",
+                                                      "ECPB", "GFXF", "GIDX", "VIDB", "WSGB"};
 
 void rpkg_function::extract_to_rt_json(std::string& input_path, std::string& filter, std::string& version,
                                        std::string& output_path) {
@@ -37,22 +43,15 @@ void rpkg_function::extract_to_rt_json(std::string& input_path, std::string& fil
         LOG_AND_RETURN("Error: Version (HM2016, HM2, or HM3) must be passed via -version on the command line.");
     }
 
-    std::vector<std::string> hm2016_valid_resources = {"TEMP", "AIRG", "TBLU", "CRMD", "ATMD", "CBLU", "CPPT", "DSWB",
-                                                       "GFXF", "GIDX", "VIDB", "WSGB"};
-    std::vector<std::string> hm2_valid_resources = {"TEMP", "AIRG", "TBLU", "CRMD", "ATMD", "CBLU", "CPPT", "DSWB",
-                                                    "ECPB", "GFXF", "GIDX", "VIDB", "WSGB"};
-    std::vector<std::string> hm3_valid_resources = {"TEMP", "AIRG", "TBLU", "CRMD", "ATMD", "CBLU", "CPPT", "DSWB",
-                                                    "ECPB", "GFXF", "GIDX", "VIDB", "WSGB"};
-
     if (!file::path_exists(input_path)) {
         LOG_AND_EXIT("Error: The RPKG file " + input_path + " does not exist.");
     }
 
     rpkg_function::import_rpkg(input_path, true);
 
-    std::vector<std::string> filters = util::parse_input_filter(filter);
+    const std::vector<std::string> filters = util::parse_input_filter(filter);
 
-    for (auto& filter : filters) {
+    for (const auto& filter : filters) {
         uint64_t text_hash_value = std::strtoull(filter.c_str(), nullptr, 16);
 
         for (uint64_t i = 0; i < rpkgs.size(); i++) {
@@ -61,7 +60,7 @@ void rpkg_function::extract_to_rt_json(std::string& input_path, std::string& fil
             if (rpkgs.at(i).rpkg_file_path != input_path)
                 continue;
 
-            std::unordered_map<uint64_t, uint64_t>::iterator it = rpkgs.at(rpkg_index).hash_map.find(text_hash_value);
+            auto it = rpkgs.at(rpkg_index).hash_map.find(text_hash_value);
 
             if (it == rpkgs.at(rpkg_index).hash_map.end())
                 continue;
@@ -113,7 +112,7 @@ void rpkg_function::extract_to_rt_json(std::string& input_path, std::string& fil
                 LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(rpkg_index).rpkg_file_path + " could not be read.");
             }
 
-            file.seekg(rpkgs.at(rpkg_index).hash.at(it->second).data.header.data_offset, file.beg);
+            file.seekg(rpkgs.at(rpkg_index).hash.at(it->second).data.header.data_offset, std::ifstream::beg);
             file.read(temp_input_data.data(), temp_hash_size);
             file.close();
 

--- a/src/generic_function.h
+++ b/src/generic_function.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <string>
+#include "global.h"
 
 class generic_function {
 public:
-    static void load_hash_list(bool exit_if_no_hash_list, std::string path = "");
+    static void load_hash_list(bool exit_if_no_hash_list, const std::string& path = "");
 
     static std::string compute_ioi_hash(const std::string& input_to_ioi_hash);
 
@@ -14,3 +15,11 @@ public:
 
     static void encrypt_packagedefinition_thumbs(std::string& input_path, std::string& output_path);
 };
+
+inline void force_load_hash_list() {
+    if (!hash_list_loaded) {
+        LOG("Loading Hash List...");
+        generic_function::load_hash_list(true);
+        LOG("Loading Hash List: Done");
+    }
+}

--- a/src/global.h
+++ b/src/global.h
@@ -354,3 +354,23 @@ extern int map_percent_progress_map_writing_changes_to_qn;
 extern std::unordered_map<uint64_t, entity> deep_search_entities_map;
 extern nlohmann::ordered_json localization_json;
 extern std::string hashes_based_on_resource_type;
+
+/**
+ * uint8_t
+ */
+#define BYTES1 1
+
+/**
+ * uint16_t
+ */
+#define BYTES2 2
+
+/**
+ * uint32_t
+ */
+#define BYTES4 4
+
+/**
+ * uint64_t
+ */
+#define BYTES8 8

--- a/src/json_to_mati.cpp
+++ b/src/json_to_mati.cpp
@@ -36,9 +36,7 @@ void rpkg_function::json_to_mati(const std::string& input_path, const std::strin
         files = file::get_recursive_file_list(input_path);
     }
 
-    LOG("Loading Hash List...");
-    generic_function::load_hash_list(true);
-    LOG("Loading Hash List: Done");
+    force_load_hash_list();
 
     for (std::filesystem::path& file : files) {
         const uint64_t hash_value = file::get_hash_value_from_path(file, ".MATI.JSON");

--- a/src/load_master_hash_list.cpp
+++ b/src/load_master_hash_list.cpp
@@ -4,11 +4,11 @@
 #include <fstream>
 #include <iostream>
 
-void generic_function::load_hash_list(bool exit_if_no_hash_list, std::string path) {
+void generic_function::load_hash_list(bool exit_if_no_hash_list, const std::string& path) {
     if (hash_list_loaded)
         return;
 
-    std::string hash_path = (path == "" ? (exe_path + std::string("\\hash_list.txt")) : path);
+    std::string hash_path = (path.empty() ? (exe_path + std::string("\\hash_list.txt")) : path);
     std::ifstream hash_list_file = std::ifstream(hash_path, std::ifstream::binary);
 
     if (file::path_exists(hash_path)) {
@@ -25,17 +25,16 @@ void generic_function::load_hash_list(bool exit_if_no_hash_list, std::string pat
         }
     }
 
-    hash_list_file.seekg(0, hash_list_file.end);
+    hash_list_file.seekg(0, std::ifstream::end);
 
     uint64_t hash_list_file_size = (uint64_t) hash_list_file.tellg();
 
-    hash_list_file.seekg(0, hash_list_file.beg);
+    hash_list_file.seekg(0, std::ifstream::beg);
 
     std::vector<char> hash_list_data(hash_list_file_size, 0);
 
     hash_list_file.read(hash_list_data.data(), hash_list_file_size);
 
-    bool done = false;
     uint64_t position = 0;
     uint64_t last_position = 0;
     uint64_t line_count = 0;
@@ -47,20 +46,19 @@ void generic_function::load_hash_list(bool exit_if_no_hash_list, std::string pat
             hash_list_data[position] = 0x0;
 
             if (line_count == 3) {
-                std::string_view temp_string_view = std::string_view(
+                auto temp_string_view = std::string_view(
                         reinterpret_cast<char*>(&hash_list_data[last_position]));
 
                 size_t pos = temp_string_view.find_first_of('=');
                 hash_list_version = std::stoi(std::string(temp_string_view.substr((pos + 1))));
             } else if (line_count > 3) {
-                std::string_view temp_string_view = std::string_view(
+                auto temp_string_view = std::string_view(
                         reinterpret_cast<char*>(&hash_list_data[last_position]));
 
                 size_t pos = temp_string_view.find_first_of(',');
-                hash_list_hash_file_names.push_back(std::string(temp_string_view.substr(0, pos)));
-                hash_list_hash_value_strings.push_back(std::string(temp_string_view.substr(0, (pos - 5))));
-                hash_list_hash_strings.push_back(
-                        std::string(temp_string_view.substr(pos + 1, temp_string_view.length() - (pos + 1))));
+                hash_list_hash_file_names.emplace_back(temp_string_view.substr(0, pos));
+                hash_list_hash_value_strings.emplace_back(temp_string_view.substr(0, (pos - 5)));
+                hash_list_hash_strings.emplace_back(temp_string_view.substr(pos + 1, temp_string_view.length() - (pos + 1)));
                 hash_list_hash_map[std::strtoull(std::string(temp_string_view.substr(0, (pos - 5))).c_str(), nullptr,
                                                  16)] = hash_list_hash_file_names.size() - 1;
             }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -727,11 +727,7 @@ void map::import_map(std::string& input_path, std::string& map_path, std::string
 
     rpkg_function::import_rpkg_files_in_folder(parent_path);
 
-    if (!hash_list_loaded) {
-        LOG("Loading Hash List...");
-        generic_function::load_hash_list(true);
-        LOG("Loading Hash List: Done");
-    }
+    force_load_hash_list();
 
     uint32_t rpkg_index = rpkg_function::get_latest_hash(map_root_hash_value);
 

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -2,7 +2,6 @@
 #include "rpkg_function.h"
 #include "global.h"
 #include "crypto.h"
-#include "console.h"
 #include "util.h"
 #include "file.h"
 #include "thirdparty/lz4/lz4.h"
@@ -10,7 +9,6 @@
 #include <map>
 #include <fstream>
 #include <sstream>
-#include <set>
 #include <filesystem>
 #include <typeinfo>
 
@@ -44,7 +42,7 @@ material::material(uint64_t rpkgs_index, uint64_t hash_index) {
         LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(mati_rpkg_index).rpkg_file_path + " could not be read.");
     }
 
-    file3.seekg(rpkgs.at(mati_rpkg_index).hash.at(mati_hash_index).data.header.data_offset, file3.beg);
+    file3.seekg(rpkgs.at(mati_rpkg_index).hash.at(mati_hash_index).data.header.data_offset, std::ifstream::beg);
     file3.read(mati_input_data.data(), mati_hash_size);
     file3.close();
 
@@ -72,39 +70,39 @@ material::material(uint64_t rpkgs_index, uint64_t hash_index) {
     matb_hash_value = 0;
 
     for (uint64_t a = 0; a < rpkgs.size(); a++) {
-        if (!(matt_hash_value && matb_hash_value)) {
-            for (uint64_t b = 0; b < rpkgs.at(a).hash.size(); b++) {
-                if (!(matt_hash_value && matb_hash_value)) {
-                    uint32_t temp_hash_reference_count =
-                            rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference_count & 0x3FFFFFFF;
+        if (matt_hash_value && matb_hash_value) continue;
 
-                    for (uint64_t c = 0; c < temp_hash_reference_count; c++) {
-                        if (rpkgs.at(a).hash.at(b).hash_resource_type == "MATT") {
-                            if (rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference.at(c) ==
-                                rpkgs.at(rpkgs_index).hash.at(hash_index).hash_value) {
-                                matt_hash_value = rpkgs.at(a).hash.at(b).hash_value;
+        for (uint64_t b = 0; b < rpkgs.at(a).hash.size(); b++) {
+            if (matt_hash_value && matb_hash_value) continue;
 
-                                uint32_t matt_hash_reference_count =
-                                        rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference_count & 0x3FFFFFFF;
+            const uint32_t temp_hash_reference_count =
+                    rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference_count & 0x3FFFFFFF;
 
-                                if (matt_hash_reference_count > 0) {
-                                    for (uint64_t i = 0; i < matt_hash_reference_count; i++) {
-                                        for (uint64_t j = 0; j < rpkgs.size(); j++) {
-                                            if (!(matt_hash_value && matb_hash_value)) {
-                                                std::unordered_map<uint64_t, uint64_t>::iterator it = rpkgs.at(
-                                                        j).hash_map.find(
-                                                        rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference.at(
-                                                                i));
+            for (uint64_t c = 0; c < temp_hash_reference_count; c++) {
+                if (rpkgs.at(a).hash.at(b).hash_resource_type != "MATT") continue;
 
-                                                if (it != rpkgs.at(j).hash_map.end()) {
-                                                    if (rpkgs.at(j).hash.at(it->second).hash_resource_type == "MATB") {
-                                                        matb_hash_value = rpkgs.at(j).hash.at(it->second).hash_value;
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                if (rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference.at(c) !=
+                    rpkgs.at(rpkgs_index).hash.at(hash_index).hash_value)
+                    continue;
+
+                matt_hash_value = rpkgs.at(a).hash.at(b).hash_value;
+
+                const uint32_t matt_hash_reference_count =
+                        rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference_count & 0x3FFFFFFF;
+
+                if (matt_hash_reference_count <= 0) continue;
+
+                for (uint64_t i = 0; i < matt_hash_reference_count; i++) {
+                    for (uint64_t j = 0; j < rpkgs.size(); j++) {
+                        if (matt_hash_value && matb_hash_value) continue;
+
+                        auto it = rpkgs.at(j).hash_map.find(
+                                rpkgs.at(a).hash.at(b).hash_reference_data.hash_reference.at(
+                                        i));
+
+                        if (it != rpkgs.at(j).hash_map.end()) {
+                            if (rpkgs.at(j).hash.at(it->second).hash_resource_type == "MATB") {
+                                matb_hash_value = rpkgs.at(j).hash.at(it->second).hash_value;
                             }
                         }
                     }
@@ -113,129 +111,131 @@ material::material(uint64_t rpkgs_index, uint64_t hash_index) {
         }
     }
 
-    if (matt_hash_value && matb_hash_value) {
-        uint32_t rpkg_index = rpkg_function::get_latest_hash(matt_hash_value);
+    if (!matt_hash_value || !matb_hash_value) {
+        return;
+    }
 
-        if (rpkg_index != UINT32_MAX) {
-            std::unordered_map<uint64_t, uint64_t>::iterator it6 = rpkgs.at(rpkg_index).hash_map.find(matt_hash_value);
+    uint32_t rpkg_index = rpkg_function::get_latest_hash(matt_hash_value);
 
-            if (it6 != rpkgs.at(rpkg_index).hash_map.end()) {
-                matt_rpkg_index = rpkg_index;
-                matt_hash_index = it6->second;
+    if (rpkg_index != UINT32_MAX) {
+        auto it6 = rpkgs.at(rpkg_index).hash_map.find(matt_hash_value);
 
-                uint32_t rpkg_index2 = rpkg_function::get_latest_hash(matb_hash_value);
+        if (it6 != rpkgs.at(rpkg_index).hash_map.end()) {
+            matt_rpkg_index = rpkg_index;
+            matt_hash_index = it6->second;
 
-                if (rpkg_index2 != UINT32_MAX) {
-                    std::unordered_map<uint64_t, uint64_t>::iterator it4 = rpkgs.at(rpkg_index2).hash_map.find(
-                            matb_hash_value);
+            uint32_t rpkg_index2 = rpkg_function::get_latest_hash(matb_hash_value);
 
-                    if (it4 != rpkgs.at(rpkg_index2).hash_map.end()) {
-                        matb_rpkg_index = rpkg_index2;
-                        matb_hash_index = it4->second;
+            if (rpkg_index2 != UINT32_MAX) {
+                auto it4 = rpkgs.at(rpkg_index2).hash_map.find(
+                        matb_hash_value);
 
-                        uint64_t matt_hash_size;
+                if (it4 != rpkgs.at(rpkg_index2).hash_map.end()) {
+                    matb_rpkg_index = rpkg_index2;
+                    matb_hash_index = it4->second;
 
-                        if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.lz4ed) {
-                            matt_hash_size = rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.header.data_size;
+                    uint64_t matt_hash_size;
 
-                            if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.xored) {
-                                matt_hash_size &= 0x3FFFFFFF;
-                            }
-                        } else {
-                            matt_hash_size = rpkgs.at(matt_rpkg_index).hash.at(
-                                    matt_hash_index).data.resource.size_final;
+                    if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.lz4ed) {
+                        matt_hash_size = rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.header.data_size;
+
+                        if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.xored) {
+                            matt_hash_size &= 0x3FFFFFFF;
                         }
-
-                        std::vector<char> matt_input_data = std::vector<char>(matt_hash_size, 0);
-
-                        std::ifstream file = std::ifstream(rpkgs.at(matt_rpkg_index).rpkg_file_path,
-                                                           std::ifstream::binary);
-
-                        if (!file.good()) {
-                            LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(matt_rpkg_index).rpkg_file_path +
-                                         " could not be read.");
-                        }
-
-                        file.seekg(rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.header.data_offset,
-                                   file.beg);
-                        file.read(matt_input_data.data(), matt_hash_size);
-                        file.close();
-
-                        if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.xored == 1) {
-                            crypto::xor_data(matt_input_data.data(), (uint32_t) matt_hash_size);
-                        }
-
-                        uint32_t matt_decompressed_size = rpkgs.at(matt_rpkg_index).hash.at(
+                    } else {
+                        matt_hash_size = rpkgs.at(matt_rpkg_index).hash.at(
                                 matt_hash_index).data.resource.size_final;
-
-                        std::vector<char> matt_output_data = std::vector<char>(matt_decompressed_size, 0);
-
-                        if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.lz4ed) {
-                            LZ4_decompress_safe(matt_input_data.data(), matt_output_data.data(), (int) matt_hash_size,
-                                                matt_decompressed_size);
-
-                            matt_data = matt_output_data;
-                        } else {
-                            matt_data = matt_input_data;
-                        }
-
-                        std::vector<char>().swap(matt_output_data);
-                        std::vector<char>().swap(matt_input_data);
-
-                        std::string matb_hash_file_name = util::uint64_t_to_hex_string(
-                                rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).hash_value) + "." +
-                                                          rpkgs.at(matb_rpkg_index).hash.at(
-                                                                  matb_hash_index).hash_resource_type;
-
-                        uint64_t matb_hash_size;
-
-                        if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.lz4ed) {
-                            matb_hash_size = rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.header.data_size;
-
-                            if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.xored) {
-                                matb_hash_size &= 0x3FFFFFFF;
-                            }
-                        } else {
-                            matb_hash_size = rpkgs.at(matb_rpkg_index).hash.at(
-                                    matb_hash_index).data.resource.size_final;
-                        }
-
-                        std::vector<char> matb_input_data = std::vector<char>(matb_hash_size, 0);
-
-                        std::ifstream file2 = std::ifstream(rpkgs.at(matb_rpkg_index).rpkg_file_path,
-                                                            std::ifstream::binary);
-
-                        if (!file2.good()) {
-                            LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(matb_rpkg_index).rpkg_file_path +
-                                         " could not be read.");
-                        }
-
-                        file2.seekg(rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.header.data_offset,
-                                    file2.beg);
-                        file2.read(matb_input_data.data(), matb_hash_size);
-                        file2.close();
-
-                        if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.xored == 1) {
-                            crypto::xor_data(matb_input_data.data(), (uint32_t) matb_hash_size);
-                        }
-
-                        uint32_t matb_decompressed_size = rpkgs.at(matb_rpkg_index).hash.at(
-                                matb_hash_index).data.resource.size_final;
-
-                        std::vector<char> matb_output_data = std::vector<char>(matb_decompressed_size, 0);
-
-                        if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.lz4ed) {
-                            LZ4_decompress_safe(matb_input_data.data(), matb_output_data.data(), (int) matb_hash_size,
-                                                matb_decompressed_size);
-
-                            matb_data = matb_output_data;
-                        } else {
-                            matb_data = matb_input_data;
-                        }
-
-                        std::vector<char>().swap(matb_output_data);
-                        std::vector<char>().swap(matb_input_data);
                     }
+
+                    std::vector<char> matt_input_data = std::vector<char>(matt_hash_size, 0);
+
+                    std::ifstream file = std::ifstream(rpkgs.at(matt_rpkg_index).rpkg_file_path,
+                                                       std::ifstream::binary);
+
+                    if (!file.good()) {
+                        LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(matt_rpkg_index).rpkg_file_path +
+                                     " could not be read.");
+                    }
+
+                    file.seekg(rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.header.data_offset,
+                               std::ifstream::beg);
+                    file.read(matt_input_data.data(), matt_hash_size);
+                    file.close();
+
+                    if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.xored == 1) {
+                        crypto::xor_data(matt_input_data.data(), (uint32_t) matt_hash_size);
+                    }
+
+                    uint32_t matt_decompressed_size = rpkgs.at(matt_rpkg_index).hash.at(
+                            matt_hash_index).data.resource.size_final;
+
+                    std::vector<char> matt_output_data = std::vector<char>(matt_decompressed_size, 0);
+
+                    if (rpkgs.at(matt_rpkg_index).hash.at(matt_hash_index).data.lz4ed) {
+                        LZ4_decompress_safe(matt_input_data.data(), matt_output_data.data(), (int) matt_hash_size,
+                                            matt_decompressed_size);
+
+                        matt_data = matt_output_data;
+                    } else {
+                        matt_data = matt_input_data;
+                    }
+
+                    std::vector<char>().swap(matt_output_data);
+                    std::vector<char>().swap(matt_input_data);
+
+                    std::string matb_hash_file_name = util::uint64_t_to_hex_string(
+                            rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).hash_value) + "." +
+                                                      rpkgs.at(matb_rpkg_index).hash.at(
+                                                              matb_hash_index).hash_resource_type;
+
+                    uint64_t matb_hash_size;
+
+                    if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.lz4ed) {
+                        matb_hash_size = rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.header.data_size;
+
+                        if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.xored) {
+                            matb_hash_size &= 0x3FFFFFFF;
+                        }
+                    } else {
+                        matb_hash_size = rpkgs.at(matb_rpkg_index).hash.at(
+                                matb_hash_index).data.resource.size_final;
+                    }
+
+                    std::vector<char> matb_input_data = std::vector<char>(matb_hash_size, 0);
+
+                    std::ifstream file2 = std::ifstream(rpkgs.at(matb_rpkg_index).rpkg_file_path,
+                                                        std::ifstream::binary);
+
+                    if (!file2.good()) {
+                        LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(matb_rpkg_index).rpkg_file_path +
+                                     " could not be read.");
+                    }
+
+                    file2.seekg(rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.header.data_offset,
+                                std::ifstream::beg);
+                    file2.read(matb_input_data.data(), matb_hash_size);
+                    file2.close();
+
+                    if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.xored == 1) {
+                        crypto::xor_data(matb_input_data.data(), (uint32_t) matb_hash_size);
+                    }
+
+                    uint32_t matb_decompressed_size = rpkgs.at(matb_rpkg_index).hash.at(
+                            matb_hash_index).data.resource.size_final;
+
+                    std::vector<char> matb_output_data = std::vector<char>(matb_decompressed_size, 0);
+
+                    if (rpkgs.at(matb_rpkg_index).hash.at(matb_hash_index).data.lz4ed) {
+                        LZ4_decompress_safe(matb_input_data.data(), matb_output_data.data(), (int) matb_hash_size,
+                                            matb_decompressed_size);
+
+                        matb_data = matb_output_data;
+                    } else {
+                        matb_data = matb_input_data;
+                    }
+
+                    std::vector<char>().swap(matb_output_data);
+                    std::vector<char>().swap(matb_input_data);
                 }
             }
         }
@@ -256,27 +256,27 @@ void material::generate_json() {
     int32_t mate_index = -1;
     uint32_t instance_offset = 0;
 
-    std::memcpy(&header_offset, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&header_offset, &mati_data[position], BYTES4);
     position = header_offset;
 
-    std::memcpy(&type_offset, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&type_offset, &mati_data[position], BYTES4);
     position += 4;
 
-    type = std::string(&mati_data.data()[type_offset]);
+    type = std::string(&mati_data[type_offset]);
 
-    std::memcpy(&texture_count, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&texture_count, &mati_data[position], BYTES4);
     position += 0x4;
 
-    std::memcpy(&class_flags, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&class_flags, &mati_data[position], BYTES4);
     position += 0x4;
 
-    std::memcpy(&instance_flags, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&instance_flags, &mati_data[position], BYTES4);
     position += 0x4;
 
-    std::memcpy(&eres_index, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&eres_index, &mati_data[position], BYTES4);
     position += 0xC;
 
-    std::memcpy(&instance_offset, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&instance_offset, &mati_data[position], BYTES4);
     position = instance_offset;
 
     if (log_output) {
@@ -342,11 +342,11 @@ void material::generate_json() {
 
         while (position < matb_data.size()) {
             uint8_t matb_type = 0;
-            std::memcpy(&matb_type, &matb_data.data()[position], sizeof(matb_type));
+            std::memcpy(&matb_type, &matb_data[position], sizeof(matb_type));
             position += sizeof(matb_type);
 
             uint32_t matb_string_length = 0;
-            std::memcpy(&matb_string_length, &matb_data.data()[position], sizeof(matb_string_length));
+            std::memcpy(&matb_string_length, &matb_data[position], sizeof(matb_string_length));
             position += sizeof(matb_string_length);
 
             std::string matb_string = "";
@@ -367,97 +367,97 @@ void material::generate_json() {
 
         while (position < matt_data.size()) {
             uint8_t matt_type = 0;
-            std::memcpy(&matt_type, &matt_data.data()[position], sizeof(matt_type));
+            std::memcpy(&matt_type, &matt_data[position], sizeof(matt_type));
             position += sizeof(matt_type);
 
             if (matt_type == 1) {
                 int32_t texture_hash_depends_index = 0;
-                std::memcpy(&texture_hash_depends_index, &matt_data.data()[position],
+                std::memcpy(&texture_hash_depends_index, &matt_data[position],
                             sizeof(texture_hash_depends_index));
                 position += sizeof(texture_hash_depends_index);
 
-                matt_entries.push_back(texture_hash_depends_index);
+                matt_entries.emplace_back(texture_hash_depends_index);
                 matt_types.push_back(matt_type);
 
                 //std::cout << "Texture: " << util::uint32_t_to_hex_string(texture_hash_depends_index) << std::endl;
             } else if (matt_type == 2) {
                 vector3 vector3_value;
 
-                std::memcpy(&vector3_value.x, &matt_data.data()[position], sizeof(vector3_value.x));
+                std::memcpy(&vector3_value.x, &matt_data[position], sizeof(vector3_value.x));
                 position += sizeof(vector3_value.x);
-                std::memcpy(&vector3_value.y, &matt_data.data()[position], sizeof(vector3_value.y));
+                std::memcpy(&vector3_value.y, &matt_data[position], sizeof(vector3_value.y));
                 position += sizeof(vector3_value.y);
-                std::memcpy(&vector3_value.z, &matt_data.data()[position], sizeof(vector3_value.z));
+                std::memcpy(&vector3_value.z, &matt_data[position], sizeof(vector3_value.z));
                 position += sizeof(vector3_value.z);
 
-                matt_entries.push_back(vector3_value);
+                matt_entries.emplace_back(vector3_value);
                 matt_types.push_back(matt_type);
 
                 //std::cout << "Float: " << util::float_to_string(vector3_value.x) << ", " << util::float_to_string(vector3_value.y) << ", " << util::float_to_string(vector3_value.z) << std::endl;
             } else if (matt_type == 3) {
                 vector4 vector4_value;
 
-                std::memcpy(&vector4_value.x, &matt_data.data()[position], sizeof(vector4_value.x));
+                std::memcpy(&vector4_value.x, &matt_data[position], sizeof(vector4_value.x));
                 position += sizeof(vector4_value.x);
-                std::memcpy(&vector4_value.y, &matt_data.data()[position], sizeof(vector4_value.y));
+                std::memcpy(&vector4_value.y, &matt_data[position], sizeof(vector4_value.y));
                 position += sizeof(vector4_value.y);
-                std::memcpy(&vector4_value.z, &matt_data.data()[position], sizeof(vector4_value.z));
+                std::memcpy(&vector4_value.z, &matt_data[position], sizeof(vector4_value.z));
                 position += sizeof(vector4_value.z);
-                std::memcpy(&vector4_value.w, &matt_data.data()[position], sizeof(vector4_value.w));
+                std::memcpy(&vector4_value.w, &matt_data[position], sizeof(vector4_value.w));
                 position += sizeof(vector4_value.w);
 
-                matt_entries.push_back(vector4_value);
+                matt_entries.emplace_back(vector4_value);
                 matt_types.push_back(matt_type);
 
                 //std::cout << "Float: " << util::float_to_string(vector3_value.x) << ", " << util::float_to_string(vector3_value.y) << ", " << util::float_to_string(vector3_value.z) << std::endl;
             } else if (matt_type == 4) {
                 float float_value = 0;
-                std::memcpy(&float_value, &matt_data.data()[position], sizeof(float_value));
+                std::memcpy(&float_value, &matt_data[position], sizeof(float_value));
                 position += sizeof(float_value);
 
-                matt_entries.push_back(float_value);
+                matt_entries.emplace_back(float_value);
                 matt_types.push_back(matt_type);
 
                 //std::cout << "Float: " << util::float_to_string(float_value) << std::endl;
             } else if (matt_type == 5) {
                 vector2 vector2_value;
 
-                std::memcpy(&vector2_value.x, &matt_data.data()[position], sizeof(vector2_value.x));
+                std::memcpy(&vector2_value.x, &matt_data[position], sizeof(vector2_value.x));
                 position += sizeof(vector2_value.x);
-                std::memcpy(&vector2_value.y, &matt_data.data()[position], sizeof(vector2_value.y));
+                std::memcpy(&vector2_value.y, &matt_data[position], sizeof(vector2_value.y));
                 position += sizeof(vector2_value.y);
 
-                matt_entries.push_back(vector2_value);
+                matt_entries.emplace_back(vector2_value);
                 matt_types.push_back(matt_type);
 
                 //std::cout << "Float: " << util::float_to_string(vector3_value.x) << ", " << util::float_to_string(vector3_value.y) << ", " << util::float_to_string(vector3_value.z) << std::endl;
             } else if (matt_type == 6) {
                 vector3 vector3_value;
 
-                std::memcpy(&vector3_value.x, &matt_data.data()[position], sizeof(vector3_value.x));
+                std::memcpy(&vector3_value.x, &matt_data[position], sizeof(vector3_value.x));
                 position += sizeof(vector3_value.x);
-                std::memcpy(&vector3_value.y, &matt_data.data()[position], sizeof(vector3_value.y));
+                std::memcpy(&vector3_value.y, &matt_data[position], sizeof(vector3_value.y));
                 position += sizeof(vector3_value.y);
-                std::memcpy(&vector3_value.z, &matt_data.data()[position], sizeof(vector3_value.z));
+                std::memcpy(&vector3_value.z, &matt_data[position], sizeof(vector3_value.z));
                 position += sizeof(vector3_value.z);
 
-                matt_entries.push_back(vector3_value);
+                matt_entries.emplace_back(vector3_value);
                 matt_types.push_back(matt_type);
 
                 //std::cout << "Float: " << util::float_to_string(vector3_value.x) << ", " << util::float_to_string(vector3_value.y) << ", " << util::float_to_string(vector3_value.z) << std::endl;
             } else if (matt_type == 7) {
                 vector4 vector4_value;
 
-                std::memcpy(&vector4_value.x, &matt_data.data()[position], sizeof(vector4_value.x));
+                std::memcpy(&vector4_value.x, &matt_data[position], sizeof(vector4_value.x));
                 position += sizeof(vector4_value.x);
-                std::memcpy(&vector4_value.y, &matt_data.data()[position], sizeof(vector4_value.y));
+                std::memcpy(&vector4_value.y, &matt_data[position], sizeof(vector4_value.y));
                 position += sizeof(vector4_value.y);
-                std::memcpy(&vector4_value.z, &matt_data.data()[position], sizeof(vector4_value.z));
+                std::memcpy(&vector4_value.z, &matt_data[position], sizeof(vector4_value.z));
                 position += sizeof(vector4_value.z);
-                std::memcpy(&vector4_value.w, &matt_data.data()[position], sizeof(vector4_value.w));
+                std::memcpy(&vector4_value.w, &matt_data[position], sizeof(vector4_value.w));
                 position += sizeof(vector4_value.w);
 
-                matt_entries.push_back(vector4_value);
+                matt_entries.emplace_back(vector4_value);
                 matt_types.push_back(matt_type);
 
                 //std::cout << "Float: " << util::float_to_string(vector3_value.x) << ", " << util::float_to_string(vector3_value.y) << ", " << util::float_to_string(vector3_value.z) << std::endl;
@@ -534,7 +534,7 @@ void material::generate_json() {
     json["Flags"]["Instance"] = decode_flags(InstanceFlags, instance_flags);
 }
 
-void material::write_json_to_file(std::string output_path) {
+void material::write_json_to_file(const std::string& output_path) const {
     std::ofstream json_file = std::ofstream(output_path, std::ofstream::binary);
 
     json_file << std::setw(4) << json << std::endl;
@@ -553,27 +553,27 @@ material::read_mati_properties_json(nlohmann::ordered_json temp_json, uint32_t p
 
     temp_mati_property.parent = parent;
 
-    temp_mati_property.name[3] = mati_data.data()[position];
+    temp_mati_property.name[3] = mati_data[position];
     position++;
-    temp_mati_property.name[2] = mati_data.data()[position];
+    temp_mati_property.name[2] = mati_data[position];
     position++;
-    temp_mati_property.name[1] = mati_data.data()[position];
+    temp_mati_property.name[1] = mati_data[position];
     position++;
-    temp_mati_property.name[0] = mati_data.data()[position];
+    temp_mati_property.name[0] = mati_data[position];
     position++;
 
-    std::memcpy(&temp_mati_property.data, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&temp_mati_property.data, &mati_data[position], BYTES4);
     position += 0x4;
 
-    std::memcpy(&temp_mati_property.size, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&temp_mati_property.size, &mati_data[position], BYTES4);
     position += 0x4;
 
-    std::memcpy(&temp_mati_property.type, &mati_data.data()[position], sizeof(bytes4));
+    std::memcpy(&temp_mati_property.type, &mati_data[position], BYTES4);
     position += 0x4;
 
     std::string mati_property_name = temp_mati_property.name;
 
-    std::unordered_map<std::string, std::string>::iterator it = mati_property_name_map.find(temp_mati_property.name);
+    auto it = mati_property_name_map.find(temp_mati_property.name);
 
     if (it != mati_property_name_map.end()) {
         mati_property_name = it->second;
@@ -594,7 +594,7 @@ material::read_mati_properties_json(nlohmann::ordered_json temp_json, uint32_t p
         if (temp_mati_property.size == 1) {
             float temp_float = 0;
 
-            std::memcpy(&temp_float, &temp_mati_property.data, sizeof(bytes4));
+            std::memcpy(&temp_float, &temp_mati_property.data, BYTES4);
 
             temp_mati_property.float_values.push_back(temp_float);
 
@@ -603,7 +603,7 @@ material::read_mati_properties_json(nlohmann::ordered_json temp_json, uint32_t p
             for (uint32_t i = 0; i < temp_mati_property.size; i++) {
                 float temp_float = 0;
 
-                std::memcpy(&temp_float, &mati_data.data()[temp_mati_property.data + i * 0x4], sizeof(bytes4));
+                std::memcpy(&temp_float, &mati_data[temp_mati_property.data + i * 0x4], BYTES4);
 
                 if (log_output)
                     std::cout << "MATI temp_mati_property.value (" << i << "): " << temp_float << std::endl;
@@ -619,7 +619,7 @@ material::read_mati_properties_json(nlohmann::ordered_json temp_json, uint32_t p
         if (log_output)
             std::cout << "MATI temp_property_type: STRING" << std::endl;
 
-        temp_mati_property.string_value = std::string(&mati_data.data()[temp_mati_property.data]);
+        temp_mati_property.string_value = std::string(&mati_data[temp_mati_property.data]);
 
         if (log_output)
             std::cout << "MATI temp_mati_property.value: " << temp_mati_property.string_value << std::endl;
@@ -638,12 +638,7 @@ material::read_mati_properties_json(nlohmann::ordered_json temp_json, uint32_t p
         if (temp_mati_property.name == "TXID") {
             if (temp_mati_property.int_value == -1) {
                 temp_json[mati_property_name] = "";
-            }
-                //else if (from_mati_file)
-                //{
-                //temp_json[mati_property_name] = util::hash_to_ioi_string(meta_data.hash_reference_data.hash_reference.at(temp_mati_property.int_value), true);
-                //}
-            else {
+            } else {
                 temp_json[mati_property_name] = util::hash_to_ioi_string(
                         rpkgs.at(mati_rpkg_index).hash.at(mati_hash_index).hash_reference_data.hash_reference.at(
                                 temp_mati_property.int_value), true);
@@ -681,7 +676,7 @@ material::read_mati_properties_json(nlohmann::ordered_json temp_json, uint32_t p
     return temp_json;
 }
 
-material::material(std::string json_path, std::string output_path) {
+material::material(const std::string& json_path, const std::string& output_path) {
     std::ifstream input_json_file(json_path);
 
     try {
@@ -710,7 +705,7 @@ material::material(std::string json_path, std::string output_path) {
 
         std::string temp_string = json["MATI"];
 
-        if (temp_string.find("[") != std::string::npos) {
+        if (temp_string.find('[') != std::string::npos) {
             mati_hash_value = util::ioi_string_to_hash(temp_string);
         } else {
             mati_hash_value = std::strtoull(temp_string.c_str(), nullptr, 16);
@@ -718,7 +713,7 @@ material::material(std::string json_path, std::string output_path) {
 
         temp_string = json["MATT"];
 
-        if (temp_string.find("[") != std::string::npos) {
+        if (temp_string.find('[') != std::string::npos) {
             matt_hash_value = util::ioi_string_to_hash(temp_string);
         } else {
             matt_hash_value = std::strtoull(temp_string.c_str(), nullptr, 16);
@@ -726,7 +721,7 @@ material::material(std::string json_path, std::string output_path) {
 
         temp_string = json["MATB"];
 
-        if (temp_string.find("[") != std::string::npos) {
+        if (temp_string.find('[') != std::string::npos) {
             matb_hash_value = util::ioi_string_to_hash(temp_string);
         } else {
             matb_hash_value = std::strtoull(temp_string.c_str(), nullptr, 16);
@@ -734,7 +729,7 @@ material::material(std::string json_path, std::string output_path) {
 
         temp_string = json["ERES"];
 
-        if (temp_string.find("[") != std::string::npos) {
+        if (temp_string.find('[') != std::string::npos) {
             eres_hash_depends = util::ioi_string_to_hash(temp_string);
         } else {
             eres_hash_depends = std::strtoull(temp_string.c_str(), nullptr, 16);
@@ -742,7 +737,7 @@ material::material(std::string json_path, std::string output_path) {
 
         temp_string = json["MATE"];
 
-        if (temp_string.find("[") != std::string::npos) {
+        if (temp_string.find('[') != std::string::npos) {
             mate_hash_depends = util::ioi_string_to_hash(temp_string);
         } else {
             mate_hash_depends = std::strtoull(temp_string.c_str(), nullptr, 16);
@@ -760,12 +755,12 @@ material::material(std::string json_path, std::string output_path) {
                     if (json["Material"]["Instance"][0]["Binder"][0]["Texture"][i].contains("Name")) {
                         temp_string = json["Material"]["Instance"][0]["Binder"][0]["Texture"][i]["Texture Id"];
 
-                        if (temp_string == "") {
+                        if (temp_string.empty()) {
                             mati_text_depends_txids.push_back(0xFFFFFFFF);
                         } else {
                             mati_text_depends_txids.push_back(texture_count);
 
-                            if (temp_string.find("[") != std::string::npos) {
+                            if (temp_string.find('[') != std::string::npos) {
                                 mati_text_depends.push_back(util::ioi_string_to_hash(temp_string));
                             } else {
                                 mati_text_depends.push_back(std::strtoull(temp_string.c_str(), nullptr, 16));
@@ -774,8 +769,7 @@ material::material(std::string json_path, std::string output_path) {
                             texture_count++;
                         }
 
-                        mati_textures.push_back(
-                                std::string(json["Material"]["Instance"][0]["Binder"][0]["Texture"][i]["Name"]));
+                        mati_textures.emplace_back(json["Material"]["Instance"][0]["Binder"][0]["Texture"][i]["Name"]);
                     }
                 }
             }
@@ -831,14 +825,14 @@ material::material(std::string json_path, std::string output_path) {
                         std::string text_name = "map" + std::string(it.key());
                         std::string text_value = std::string(it.value());
 
-                        if (text_value == "") {
+                        if (text_value.empty()) {
                             matt_textures.push_back(false);
                         } else {
                             if (std::find(mati_textures.begin(), mati_textures.end(), text_name) !=
                                 mati_textures.end()) {
                                 matt_textures.push_back(true);
 
-                                if (text_value.find("[") != std::string::npos)
+                                if (text_value.find('[') != std::string::npos)
                                     matt_text_depends.push_back(util::ioi_string_to_hash(text_value));
                                 else
                                     matt_text_depends.push_back(std::strtoull(text_value.c_str(), nullptr, 16));
@@ -853,16 +847,18 @@ material::material(std::string json_path, std::string output_path) {
             }
         }
 
-        uint32_t mati_hash_reference_table_size = mati_hash_depends_count * 0x8 + mati_hash_depends_count + 0x4;
+        const uint32_t mati_hash_reference_table_size = mati_hash_depends_count * 0x8 + mati_hash_depends_count + 0x4;
         mati_hash_depends_count = mati_hash_depends_count | 0xC0000000;
         write_uint32_t(mati_meta_data, mati_hash_reference_table_size);
 
         if (matt_hash_value && matb_hash_value) {
-            uint32_t matt_hash_reference_table_size = matt_hash_depends_count * 0x8 + matt_hash_depends_count + 0x4;
+            const uint32_t matt_hash_reference_table_size =
+                    matt_hash_depends_count * 0x8 + matt_hash_depends_count + 0x4;
             matt_hash_depends_count = matt_hash_depends_count | 0xC0000000;
             write_uint32_t(matt_meta_data, matt_hash_reference_table_size);
 
-            uint32_t matb_hash_reference_table_size = matb_hash_depends_count * 0x8 + matb_hash_depends_count + 0x4;
+            const uint32_t matb_hash_reference_table_size =
+                    matb_hash_depends_count * 0x8 + matb_hash_depends_count + 0x4;
             matb_hash_depends_count = matb_hash_depends_count | 0xC0000000;
             write_uint32_t(matb_meta_data, matb_hash_reference_table_size);
         }
@@ -874,9 +870,9 @@ material::material(std::string json_path, std::string output_path) {
             write_uint32_t(matb_meta_data, 0);
         }
 
-        uint32_t mati_size_offset = mati_meta_data.size();
-        uint32_t matt_size_offset = matt_meta_data.size();
-        uint32_t matb_size_offset = matb_meta_data.size();
+        const uint32_t mati_size_offset = mati_meta_data.size();
+        const uint32_t matt_size_offset = matt_meta_data.size();
+        const uint32_t matb_size_offset = matb_meta_data.size();
 
         write_uint32_t(mati_meta_data, 0);
 
@@ -927,7 +923,7 @@ material::material(std::string json_path, std::string output_path) {
 
         if (matt_hash_value && matb_hash_value) {
             //00B4B11DA327CAD0.CPPT 1F [modules:/zrendermaterialentity.class].pc_entitytype
-            uint64_t matt_cppt_hash = 0x00B4B11DA327CAD0;
+            constexpr uint64_t matt_cppt_hash = 0x00B4B11DA327CAD0;
 
             for (uint32_t k = 0; k < sizeof(matt_cppt_hash); k++) {
                 matt_meta_data.push_back(*((char*) &matt_cppt_hash + k));
@@ -942,7 +938,7 @@ material::material(std::string json_path, std::string output_path) {
             }
 
             //00A1595C0918E2C9.CBLU 1F[modules:/zrendermaterialentity.class].pc_entityblueprint;
-            uint64_t matb_cblu_hash = 0x00A1595C0918E2C9;
+            constexpr uint64_t matb_cblu_hash = 0x00A1595C0918E2C9;
 
             for (uint32_t k = 0; k < sizeof(matb_cblu_hash); k++) {
                 matb_meta_data.push_back(*((char*) &matb_cblu_hash + k));
@@ -951,17 +947,17 @@ material::material(std::string json_path, std::string output_path) {
 
         int32_t eres_index = 0;
 
-        for (uint32_t i = 0; i < mati_text_depends.size(); i++) {
-            for (uint32_t k = 0; k < sizeof(mati_text_depends.at(i)); k++) {
-                mati_meta_data.push_back(*((char*) &mati_text_depends.at(i) + k));
+        for (const auto& mati_text_depend : mati_text_depends) {
+            for (uint32_t k = 0; k < sizeof(mati_text_depend); k++) {
+                mati_meta_data.push_back(*((char*) &mati_text_depend + k));
             }
 
             eres_index++;
         }
 
-        for (uint32_t i = 0; i < matt_text_depends.size(); i++) {
-            for (uint32_t k = 0; k < sizeof(matt_text_depends.at(i)); k++) {
-                matt_meta_data.push_back(*((char*) &matt_text_depends.at(i) + k));
+        for (const auto& matt_text_depend : matt_text_depends) {
+            for (uint32_t k = 0; k < sizeof(matt_text_depend); k++) {
+                matt_meta_data.push_back(*((char*) &matt_text_depend + k));
             }
         }
 
@@ -989,7 +985,7 @@ material::material(std::string json_path, std::string output_path) {
         write_string(mati_data, type);
         align(mati_data);
 
-        uint32_t instance_offset = (mati_data.size() + 0x30);
+        const uint32_t instance_offset = (mati_data.size() + 0x30);
 
         write_uint32_t(mati_data, (uint32_t) 0x10);
         write_uint32_t(mati_data, texture_count);
@@ -1128,8 +1124,8 @@ material::material(std::string json_path, std::string output_path) {
 
                     std::memcpy(&mati_data[offsets_values.at(i)], &temp_offset, 0x4);
 
-                    for (uint32_t i = 0; i < temp_json.size(); i++) {
-                        write_float(mati_data, temp_json[i]);
+                    for (const auto& i : temp_json) {
+                        write_float(mati_data, i);
                     }
 
                     align(mati_data);
@@ -1266,7 +1262,7 @@ material::material(std::string json_path, std::string output_path) {
         mati_file.write(mati_data.data(), mati_data.size());
         mati_file.close();
         uint32_t mati_data_size = mati_data.size();
-        std::memcpy(&mati_meta_data.data()[mati_size_offset], &mati_data_size, 0x4);
+        std::memcpy(&mati_meta_data[mati_size_offset], &mati_data_size, 0x4);
         mati_meta_file.write(mati_meta_data.data(), mati_meta_data.size());
         mati_meta_file.close();
 
@@ -1274,14 +1270,14 @@ material::material(std::string json_path, std::string output_path) {
             matt_file.write(matt_data.data(), matt_data.size());
             matt_file.close();
             uint32_t matt_data_size = matt_data.size();
-            std::memcpy(&matt_meta_data.data()[matt_size_offset], &matt_data_size, 0x4);
+            std::memcpy(&matt_meta_data[matt_size_offset], &matt_data_size, 0x4);
             matt_meta_file.write(matt_meta_data.data(), matt_meta_data.size());
             matt_meta_file.close();
 
             matb_file.write(matb_data.data(), matb_data.size());
             matb_file.close();
             uint32_t matb_data_size = matb_data.size();
-            std::memcpy(&matb_meta_data.data()[matb_size_offset], &matb_data_size, 0x4);
+            std::memcpy(&matb_meta_data[matb_size_offset], &matb_data_size, 0x4);
             matb_meta_file.write(matb_meta_data.data(), matb_meta_data.size());
             matb_meta_file.close();
         }
@@ -1296,8 +1292,8 @@ material::material(std::string json_path, std::string output_path) {
     }
 }
 
-MATI_PROPERTY_TYPE material::get_property_type(std::string key) {
-    std::unordered_map<std::string, MATI_PROPERTY_TYPE>::iterator it = mati_property_type_map.find(key);
+MATI_PROPERTY_TYPE material::get_property_type(const std::string& key) const {
+    auto it = mati_property_type_map.find(key);
 
     if (it != mati_property_type_map.end()) {
         return it->second;
@@ -1322,9 +1318,9 @@ void material::write_uint32_t(std::vector<char>& material_data, uint32_t data) {
     }
 }
 
-void material::write_string(std::vector<char>& material_data, std::string data) {
-    for (int i = 0; i < data.length(); i++) {
-        material_data.push_back(data[i]);
+void material::write_string(std::vector<char>& material_data, const std::string& data) {
+    for (char i : data) {
+        material_data.push_back(i);
     }
 
     material_data.push_back(0x0);
@@ -1347,8 +1343,8 @@ void material::write_name(std::vector<char>& material_data, std::string name) {
     material_data.push_back(name[0]);
 }
 
-void material::write_property_type(std::vector<char>& material_data, std::string name) {
-    std::unordered_map<std::string, MATI_PROPERTY_TYPE>::iterator it = mati_property_type_map.find(name);
+void material::write_property_type(std::vector<char>& material_data, const std::string& name) {
+    auto it = mati_property_type_map.find(name);
 
     if (it != mati_property_type_map.end()) {
         write_uint32_t(mati_data, (uint32_t) it->second);
@@ -1356,7 +1352,7 @@ void material::write_property_type(std::vector<char>& material_data, std::string
 }
 
 std::string material::get_property_name(std::string property) {
-    std::unordered_map<std::string, std::string>::iterator it = mati_property_name_map_reversed.find(property);
+    auto it = mati_property_name_map_reversed.find(property);
 
     if (it != mati_property_name_map_reversed.end()) {
         return it->second;

--- a/src/material.h
+++ b/src/material.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <variant>
 #include "hash.h"
 #include "global.h"
@@ -34,30 +34,30 @@ public:
 
     material(uint64_t rpkgs_index, uint64_t hash_index);
 
-    material(std::string json_path, std::string output_path);
+    material(const std::string& json_path, const std::string& output_path);
     //material(std::string material_path, std::string material_meta_path, uint64_t hash_value, std::string output_path, bool output_path_is_file);
 
     void generate_json();
 
-    void write_json_to_file(std::string output_path);
+    void write_json_to_file(const std::string& output_path) const;
 
     nlohmann::ordered_json
     read_mati_properties_json(nlohmann::ordered_json temp_json, uint32_t position, uint32_t parent,
                               bool from_mati_file);
 
-    MATI_PROPERTY_TYPE get_property_type(std::string key);
+    [[nodiscard]] MATI_PROPERTY_TYPE get_property_type(const std::string& key) const;
 
-    void align(std::vector<char>& material_data);
+    static void align(std::vector<char>& material_data);
 
-    void write_uint32_t(std::vector<char>& material_data, uint32_t data);
+    static void write_uint32_t(std::vector<char>& material_data, uint32_t data);
 
-    void write_string(std::vector<char>& material_data, std::string data);
+    static void write_string(std::vector<char>& material_data, const std::string& data);
 
-    void write_float(std::vector<char>& material_data, float data);
+    static void write_float(std::vector<char>& material_data, float data);
 
-    void write_name(std::vector<char>& material_data, std::string name);
+    static void write_name(std::vector<char>& material_data, std::string name);
 
-    void write_property_type(std::vector<char>& material_data, std::string name);
+    void write_property_type(std::vector<char>& material_data, const std::string& name);
 
     std::string get_property_name(std::string property);
 
@@ -85,7 +85,8 @@ public:
     std::string json_error = "";
     std::string type = "";
     std::vector<mati_property> mati_properties;
-    std::vector<std::string> ClassFlags = {
+
+    const std::vector<std::string> ClassFlags = {
             "REFLECTION2D",
             "REFRACTION2D",
             "LIGHTING",
@@ -109,7 +110,8 @@ public:
             "UNKNOWN_4",
             "UNKNOWN_5"
     };
-    std::vector<std::string> InstanceFlags = {
+
+    const std::vector<std::string> InstanceFlags = {
             "OPAQUE_EMISSIVE",
             "TRANS_EMISSIVE",
             "TRANSADD_EMISSIVE",
@@ -125,7 +127,8 @@ public:
             "DECAL_EMISSIVE",
             "WATER_CLIPPING"
     };
-    std::unordered_map<std::string, std::string> mati_property_name_map = {
+
+    const std::unordered_map<std::string, std::string> mati_property_name_map = {
             {"AREF", "Alpha Reference"},
             {"ATST", "Alpha Test Enabled"},
             {"BENA", "Blend Enabled"},
@@ -158,7 +161,8 @@ public:
             {"VALU", "Value"},
             {"ZBIA", "Z Bias"},
             {"ZOFF", "Z Offset"}};
-    std::unordered_map<std::string, std::string> mati_property_name_map_reversed = {
+
+    const std::unordered_map<std::string, std::string> mati_property_name_map_reversed = {
             {"Alpha Reference",       "AREF"},
             {"Alpha Test Enabled",    "ATST"},
             {"Blend Enabled",         "BENA"},
@@ -191,7 +195,8 @@ public:
             {"Value",                 "VALU"},
             {"Z Bias",                "ZBIA"},
             {"Z Offset",              "ZOFF"}};
-    std::unordered_map<std::string, MATI_PROPERTY_TYPE> mati_property_type_map = {
+
+    const std::unordered_map<std::string, MATI_PROPERTY_TYPE> mati_property_type_map = {
             {"AREF", MATI_PROPERTY_TYPE::INT},
             {"ATST", MATI_PROPERTY_TYPE::INT},
             {"BENA", MATI_PROPERTY_TYPE::INT},

--- a/src/prim.cpp
+++ b/src/prim.cpp
@@ -77,11 +77,9 @@ prim::prim(uint64_t rpkgs_index, uint64_t hash_index) {
 
     if (it2 != hash_list_hash_map.end()) {
         //LOG("  - IOI String: " + hash_list_hash_strings.at(it2->second));
-    } else {
-        //LOG("  - IOI String: ");
     }
 
-    std::memcpy(&prim_primary_header_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&prim_primary_header_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("  - PRIM primary header offset: " + util::uint32_t_to_hex_string(prim_primary_header_offset));
@@ -96,22 +94,18 @@ prim::prim(uint64_t rpkgs_index, uint64_t hash_index) {
         //LOG("  - PRIM primary header type: Object");
     } else if (primary_prim_object_header.prim_header_instance.type == (uint16_t) prim_header::header_type::MESH) {
         //LOG("Error: Not supported: PRIM primary header type: Mesh");
-
         success = false;
-
         return;
     } else {
         //LOG("Error: Not supported: PRIM primary header type: Unknown");
-
         success = false;
-
         return;
     }
 
     prim_position = primary_prim_object_header.object_offset;
 
     for (uint32_t o = 0; o < primary_prim_object_header.object_count; o++) {
-        std::memcpy(&bytes4, &prim_data.data()[prim_position], sizeof(bytes4));
+        std::memcpy(&bytes4, &prim_data[prim_position], BYTES4);
         prim_position += 0x4;
 
         prim_object_offsets.push_back(bytes4);
@@ -131,39 +125,39 @@ prim::prim(uint64_t rpkgs_index, uint64_t hash_index) {
 
         prim_position += 0x2;
 
-        std::memcpy(&header_type_value, &prim_data.data()[prim_position], sizeof(bytes2));
+        std::memcpy(&header_type_value, &prim_data[prim_position], BYTES2);
 
         prim_position += 0x2;
 
         //LOG("      - PRIM object (" + std::to_string(o) + ") header type value: " + util::uint16_t_to_hex_string(header_type_value));
 
-        if (header_type_value == 1) {
+//        if (header_type_value == 1) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header type: Object");
-        } else if (header_type_value == 2) {
+//        } else if (header_type_value == 2) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header type: Mesh");
-        } else {
+//        } else {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header type: Unknown");
-        }
+//        }
 
-        std::memcpy(&object_sub_type_value, &prim_data.data()[prim_position], sizeof(bytes1));
+        std::memcpy(&object_sub_type_value, &prim_data[prim_position], BYTES1);
 
         //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type value: " + util::uint8_t_to_hex_string(object_sub_type_value));
 
-        if (object_sub_type_value == 0x0) {
+//        if (object_sub_type_value == 0x0) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: Standard");
-        } else if (object_sub_type_value == 0x1) {
+//        } else if (object_sub_type_value == 0x1) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: Linked");
-        } else if (object_sub_type_value == 0x2) {
+//        } else if (object_sub_type_value == 0x2) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: Weighted");
-        } else if (object_sub_type_value == 0x3) {
+//        } else if (object_sub_type_value == 0x3) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: StandardUUV2");
-        } else if (object_sub_type_value == 0x4) {
+//        } else if (object_sub_type_value == 0x4) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: StandardUUV3");
-        } else if (object_sub_type_value == 0x5) {
+//        } else if (object_sub_type_value == 0x5) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: StandardUUV4");
-        } else if (object_sub_type_value == 0x6) {
+//        } else if (object_sub_type_value == 0x6) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: SpeedTree");
-        }
+//        }
 
         prim_position = prim_object_offsets.at(o);
 
@@ -242,9 +236,7 @@ prim::prim(uint64_t rpkgs_index, uint64_t hash_index) {
                 }
             } else {
                 //LOG("Error: Not supported: PRIM object type: " + util::uint32_t_to_hex_string(object_sub_type_value));
-
                 success = false;
-
                 return;
             }
         }
@@ -337,7 +329,7 @@ prim::prim(const std::string& prim_file_path) {
 
     //LOG("PRIM file: " + prim_file_name);
 
-    std::memcpy(&prim_primary_header_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&prim_primary_header_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("  - PRIM primary header offset: " + util::uint32_t_to_hex_string(prim_primary_header_offset));
@@ -352,22 +344,18 @@ prim::prim(const std::string& prim_file_path) {
         //LOG("  - PRIM primary header type: Object");
     } else if (primary_prim_object_header.prim_header_instance.type == (uint16_t) prim_header::header_type::MESH) {
         //LOG("Error: Not supported: PRIM primary header type: Mesh");
-
         success = false;
-
         return;
     } else {
         //LOG("Error: Not supported: PRIM primary header type: Unknown");
-
         success = false;
-
         return;
     }
 
     prim_position = primary_prim_object_header.object_offset;
 
     for (uint32_t o = 0; o < primary_prim_object_header.object_count; o++) {
-        std::memcpy(&bytes4, &prim_data.data()[prim_position], sizeof(bytes4));
+        std::memcpy(&bytes4, &prim_data[prim_position], BYTES4);
         prim_position += 0x4;
 
         prim_object_offsets.push_back(bytes4);
@@ -387,39 +375,39 @@ prim::prim(const std::string& prim_file_path) {
 
         prim_position += 0x2;
 
-        std::memcpy(&header_type_value, &prim_data.data()[prim_position], sizeof(bytes2));
+        std::memcpy(&header_type_value, &prim_data[prim_position], BYTES2);
 
         prim_position += 0x2;
 
         //LOG("      - PRIM object (" + std::to_string(o) + ") header type value: " + util::uint16_t_to_hex_string(header_type_value));
 
-        if (header_type_value == 1) {
+//        if (header_type_value == 1) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header type: Object");
-        } else if (header_type_value == 2) {
+//        } else if (header_type_value == 2) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header type: Mesh");
-        } else {
+//        } else {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header type: Unknown");
-        }
+//        }
 
-        std::memcpy(&object_sub_type_value, &prim_data.data()[prim_position], sizeof(bytes1));
+        std::memcpy(&object_sub_type_value, &prim_data[prim_position], BYTES1);
 
         //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type value: " + util::uint8_t_to_hex_string(object_sub_type_value));
 
-        if (object_sub_type_value == 0x0) {
+//        if (object_sub_type_value == 0x0) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: Standard");
-        } else if (object_sub_type_value == 0x1) {
+//        } else if (object_sub_type_value == 0x1) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: Linked");
-        } else if (object_sub_type_value == 0x2) {
-            //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: Weighted");
-        } else if (object_sub_type_value == 0x3) {
+//        } else if (object_sub_type_value == 0x2) {
+//            LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: Weighted");
+//        } else if (object_sub_type_value == 0x3) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: StandardUUV2");
-        } else if (object_sub_type_value == 0x4) {
+//        } else if (object_sub_type_value == 0x4) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: StandardUUV3");
-        } else if (object_sub_type_value == 0x5) {
+//        } else if (object_sub_type_value == 0x5) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: StandardUUV4");
-        } else if (object_sub_type_value == 0x6) {
+//        } else if (object_sub_type_value == 0x6) {
             //LOG("      - PRIM object (" + std::to_string(o) + ") header sub type: SpeedTree");
-        }
+//        }
 
         prim_position = prim_object_offsets.at(o);
 
@@ -495,21 +483,19 @@ prim::prim(const std::string& prim_file_path) {
                 }
             } else {
                 //LOG("Error: Not supported: PRIM object type: " + util::uint32_t_to_hex_string(object_sub_type_value));
-
                 success = false;
-
                 return;
             }
         }
     }
 
-    if (!borg_depends_file_name.empty()) {
+//    if (!borg_depends_file_name.empty()) {
         //borg temp_borg(borg_depends_rpkg_index.at(0).at(borg_depends_rpkg_index_index.at(0)), borg_depends_hash_index.at(0).at(borg_depends_hash_index_index.at(0)));
 
         //asset3ds_data.bones_data = temp_borg.bones_data;
         //asset3ds_data.bones_positions = temp_borg.bones_positions;
         //asset3ds_data.bones_inverse_matrices = temp_borg.bones_inverse_bind_matrices;
-    }
+//    }
 
     asset3ds_data.weighted = prim_object_is_weighted;
 }
@@ -614,20 +600,20 @@ void prim::load_hash_depends() {
         long patch_level = 0;
 
         for (uint64_t d = 0; d < mati_depends_in_rpkgs.at(k).size(); d++) {
-            std::string mati_depends_in_rpkgs_upper_case = util::to_upper_case(mati_depends_in_rpkgs.at(k).at(d));
+            const std::string mati_depends_in_rpkgs_upper_case = util::to_upper_case(mati_depends_in_rpkgs.at(k).at(d));
 
-            std::string_view mati_depends_in_rpkgs_string_view(mati_depends_in_rpkgs_upper_case.c_str(),
+            const std::string_view mati_depends_in_rpkgs_string_view(mati_depends_in_rpkgs_upper_case.c_str(),
                                                                mati_depends_in_rpkgs_upper_case.length());
 
-            size_t pos1 = mati_depends_in_rpkgs_string_view.find("PATCH");
+            const size_t pos1 = mati_depends_in_rpkgs_string_view.find("PATCH");
 
             if (pos1 != std::string::npos) {
-                size_t pos2 = mati_depends_in_rpkgs_string_view.substr(pos1).find('.');
+                const size_t pos2 = mati_depends_in_rpkgs_string_view.substr(pos1).find('.');
 
                 if (pos2 != std::string::npos) {
                     mati_patch_name_found = true;
 
-                    long new_patch_level = std::strtol(
+                    const long new_patch_level = std::strtol(
                             std::string(mati_depends_in_rpkgs_string_view.substr(pos1 + 5, pos2)).c_str(), nullptr, 10);
 
                     if (new_patch_level > patch_level) {
@@ -660,12 +646,12 @@ void prim::load_hash_depends() {
         long patch_level = 0;
 
         for (uint64_t d = 0; d < borg_depends_in_rpkgs.at(k).size(); d++) {
-            std::string borg_depends_in_rpkgs_upper_case = util::to_upper_case(borg_depends_in_rpkgs.at(k).at(d));
+            const std::string borg_depends_in_rpkgs_upper_case = util::to_upper_case(borg_depends_in_rpkgs.at(k).at(d));
 
-            std::string_view borg_depends_in_rpkgs_string_view(borg_depends_in_rpkgs_upper_case.c_str(),
+            const std::string_view borg_depends_in_rpkgs_string_view(borg_depends_in_rpkgs_upper_case.c_str(),
                                                                borg_depends_in_rpkgs_upper_case.length());
 
-            size_t pos1 = borg_depends_in_rpkgs_string_view.find("PATCH");
+            const size_t pos1 = borg_depends_in_rpkgs_string_view.find("PATCH");
 
             if (pos1 != std::string::npos) {
                 size_t pos2 = borg_depends_in_rpkgs_string_view.substr(pos1).find('.');
@@ -673,7 +659,7 @@ void prim::load_hash_depends() {
                 if (pos2 != std::string::npos) {
                     borg_patch_name_found = true;
 
-                    long new_patch_level = std::strtol(
+                    const long new_patch_level = std::strtol(
                             std::string(borg_depends_in_rpkgs_string_view.substr(pos1 + 5, pos2)).c_str(), nullptr, 10);
 
                     if (new_patch_level > patch_level) {
@@ -709,17 +695,17 @@ prim::prim_header::prim_header(std::vector<char>& prim_data, uint32_t& prim_posi
 
     offset = prim_position;
 
-    std::memcpy(&draw, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&draw, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     //LOG("  - PRIM header draw value: " + util::uint8_t_to_hex_string(draw));
 
-    std::memcpy(&pack, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&pack, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     //LOG("  - PRIM header pack value: " + util::uint8_t_to_hex_string(draw));
 
-    std::memcpy(&type, &prim_data.data()[prim_position], sizeof(bytes2));
+    std::memcpy(&type, &prim_data[prim_position], BYTES2);
     prim_position += 0x2;
 
     //LOG("  - PRIM header type value: " + util::uint16_t_to_hex_string(type));
@@ -735,7 +721,7 @@ prim::prim_object_header::prim_object_header(std::vector<char>& prim_data, uint3
 
     prim_header_instance = prim_header(prim_data, prim_position);
 
-    std::memcpy(&property_flags, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&property_flags, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("  - PRIM primary header property flags: " + util::uint32_t_to_hex_string(property_flags));
@@ -771,33 +757,33 @@ prim::prim_object_header::prim_object_header(std::vector<char>& prim_data, uint3
         //LOG("  - PRIM primary header flag set: High Resolution");
     }
 
-    std::memcpy(&borg_index, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&borg_index, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("  - PRIM primary BORG index: " + util::uint32_t_to_hex_string(borg_index));
 
-    std::memcpy(&object_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&object_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("  - PRIM primary object count: " + util::uint32_t_to_hex_string(object_count));
 
-    std::memcpy(&object_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&object_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("  - PRIM primary object offset: " + util::uint32_t_to_hex_string(object_offset));
 
-    std::memcpy(&bounding_box_min.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_min.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_min.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_min.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_min.z, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_min.z, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
-    std::memcpy(&bounding_box_max.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_max.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_max.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_max.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_max.z, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_max.z, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("  - PRIM primary bounding box min:");
@@ -823,122 +809,122 @@ prim::prim_object::prim_object(std::vector<char>& prim_data, uint32_t& prim_posi
 
     object = prim_object_number;
 
-    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     sub_type = bytes1;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type value: " + util::uint8_t_to_hex_string(sub_type));
 
-    if (sub_type == 0x0) {
+//    if (sub_type == 0x0) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type: Standard");
-    } else if (sub_type == 0x1) {
+//    } else if (sub_type == 0x1) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type: Linked");
-    } else if (sub_type == 0x2) {
+//    } else if (sub_type == 0x2) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type: Weighted");
-    } else if (sub_type == 0x3) {
+//    } else if (sub_type == 0x3) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type: StandardUUV2");
-    } else if (sub_type == 0x4) {
+//    } else if (sub_type == 0x4) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type: StandardUUV3");
-    } else if (sub_type == 0x5) {
+//    } else if (sub_type == 0x5) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type: StandardUUV4");
-    } else if (sub_type == 0x6) {
+//    } else if (sub_type == 0x6) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header sub type: SpeedTree");
-    }
+//    }
 
-    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     property_flags = bytes1;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") header property flags: " + util::uint8_t_to_hex_string(property_flags));
 
-    if (property_flags == 0x0) {
+//    if (property_flags == 0x0) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: None");
-    }
-    if ((property_flags & 0x1) == 0x1) {
+//    }
+//    if ((property_flags & 0x1) == 0x1) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: XAxisLocked");
-    }
-    if ((property_flags & 0x2) == 0x2) {
+//    }
+//    if ((property_flags & 0x2) == 0x2) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: YAxisLocked");
-    }
-    if ((property_flags & 0x4) == 0x4) {
+//    }
+//    if ((property_flags & 0x4) == 0x4) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: ZAxisLocked");
-    }
-    if ((property_flags & 0x8) == 0x8) {
+//    }
+//    if ((property_flags & 0x8) == 0x8) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: 32BitVertexData");
-    }
-    if ((property_flags & 0x10) == 0x10) {
+//    }
+//    if ((property_flags & 0x10) == 0x10) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: PS3");
-    }
-    if ((property_flags & 0x20) == 0x20) {
+//    }
+//    if ((property_flags & 0x20) == 0x20) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: Color1");
-    }
-    if ((property_flags & 0x40) == 0x40) {
+//    }
+//    if ((property_flags & 0x40) == 0x40) {
         //LOG("      - PRIM object (" + std::to_string(object) + ") header flag set: NoPhysics");
-    }
+//    }
 
-    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     lod = bytes1;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") LOD: " + util::uint8_t_to_hex_string(lod));
 
-    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     variant = bytes1;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") variant: " + util::uint8_t_to_hex_string(variant));
 
-    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     bias = bytes1;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") bias: " + util::uint8_t_to_hex_string(bias));
 
-    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
+    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
     prim_position += 0x1;
 
     offset = bytes1;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") offset: " + util::uint8_t_to_hex_string(offset));
 
-    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
+    std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
     prim_position += 0x2;
 
     material_id = bytes2;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") material id: " + util::uint16_t_to_hex_string(material_id));
 
-    std::memcpy(&bytes4, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bytes4, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     wire_color = bytes4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") object wire color: " + util::uint32_t_to_hex_string(wire_color));
 
-    std::memcpy(&bytes4, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bytes4, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     color = bytes4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") object color: " + util::uint32_t_to_hex_string(color));
 
-    std::memcpy(&bounding_box_min.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_min.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_min.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_min.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_min.z, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_min.z, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
-    std::memcpy(&bounding_box_max.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_max.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_max.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_max.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&bounding_box_max.z, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bounding_box_max.z, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") bounding box min:");
@@ -964,18 +950,18 @@ prim::prim_mesh::prim_mesh(std::vector<char>& prim_data, uint32_t& prim_position
 
     uint32_t object = prim_object_number;
 
-    std::memcpy(&sub_mesh_table_offset_pointer, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&sub_mesh_table_offset_pointer, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh table offset pointer:" + util::uint32_t_to_hex_string(sub_mesh_table_offset_pointer));
 
-    std::memcpy(&vertex_position_scale.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_scale.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&vertex_position_scale.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_scale.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&vertex_position_scale.z, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_scale.z, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&vertex_position_scale.w, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_scale.w, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") mesh vertex position scale:");
@@ -984,13 +970,13 @@ prim::prim_mesh::prim_mesh(std::vector<char>& prim_data, uint32_t& prim_position
     //LOG("          - z: " + util::float_to_string(vertex_position_scale.z));
     //LOG("          - w: " + util::float_to_string(vertex_position_scale.w));
 
-    std::memcpy(&vertex_position_bias.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_bias.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&vertex_position_bias.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_bias.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&vertex_position_bias.z, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_bias.z, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&vertex_position_bias.w, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_position_bias.w, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") mesh vertex position bias:");
@@ -999,25 +985,25 @@ prim::prim_mesh::prim_mesh(std::vector<char>& prim_data, uint32_t& prim_position
     //LOG("          - z: " + util::float_to_string(vertex_position_bias.z));
     //LOG("          - w: " + util::float_to_string(vertex_position_bias.w));
 
-    std::memcpy(&uv_position_scale.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&uv_position_scale.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&uv_position_scale.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&uv_position_scale.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") mesh uv position bias:");
     //LOG("          - x: " + util::float_to_string(uv_position_scale.x));
     //LOG("          - y: " + util::float_to_string(uv_position_scale.y));
 
-    std::memcpy(&uv_position_bias.x, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&uv_position_bias.x, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
-    std::memcpy(&uv_position_bias.y, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&uv_position_bias.y, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") mesh uv position bias:");
     //LOG("          - x: " + util::float_to_string(uv_position_bias.x));
     //LOG("          - y: " + util::float_to_string(uv_position_bias.y));
 
-    std::memcpy(&cloth_flags, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&cloth_flags, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") mesh cloth flags:" + util::uint32_t_to_hex_string(cloth_flags));
@@ -1026,7 +1012,7 @@ prim::prim_mesh::prim_mesh(std::vector<char>& prim_data, uint32_t& prim_position
 
     prim_position = sub_mesh_table_offset_pointer;
 
-    std::memcpy(&sub_mesh_table_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&sub_mesh_table_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh table offset:" + util::uint32_t_to_hex_string(sub_mesh_table_offset));
@@ -1047,22 +1033,22 @@ prim::prim_weighted_mesh::prim_weighted_mesh(std::vector<char>& prim_data, uint3
 
     uint32_t object = prim_object_number;
 
-    std::memcpy(&bones_nodes_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bones_nodes_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") bones nodes count:" + util::uint32_t_to_hex_string(bones_nodes_count));
 
-    std::memcpy(&bones_nodes_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bones_nodes_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") bones nodes offset:" + util::uint32_t_to_hex_string(bones_nodes_offset));
 
-    std::memcpy(&bone_indices_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bone_indices_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") bones indices offset:" + util::uint32_t_to_hex_string(bone_indices_offset));
 
-    std::memcpy(&bone_info_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&bone_info_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("      - PRIM object (" + std::to_string(object) + ") bones info offset:" + util::uint32_t_to_hex_string(bone_info_offset));
@@ -1087,47 +1073,47 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
 
     uint32_t object = prim_object_number;
 
-    std::memcpy(&vertex_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex count: " + util::uint32_t_to_hex_string(vertex_count));
 
-    std::memcpy(&vertex_buffer_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_buffer_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex buffer offset: " + util::uint32_t_to_hex_string(vertex_buffer_offset));
 
-    std::memcpy(&index_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&index_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh index count: " + util::uint32_t_to_hex_string(index_count));
 
-    std::memcpy(&index_count_additional, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&index_count_additional, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh index count additional: " + util::uint32_t_to_hex_string(index_count_additional));
 
-    std::memcpy(&index_buffer_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&index_buffer_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh index buffer offset: " + util::uint32_t_to_hex_string(index_buffer_offset));
 
-    std::memcpy(&collision_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&collision_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh collision offset: " + util::uint32_t_to_hex_string(collision_offset));
 
-    std::memcpy(&cloth_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&cloth_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh cloth offset: " + util::uint32_t_to_hex_string(cloth_offset));
 
-    std::memcpy(&uv_channel_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&uv_channel_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh uv channel count: " + util::uint32_t_to_hex_string(uv_channel_count));
 
-    std::memcpy(&unknown_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&unknown_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh unknown offset: " + util::uint32_t_to_hex_string(unknown_offset));
@@ -1140,8 +1126,8 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
         //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh indexes at (" + util::uint32_t_to_hex_string(index_buffer_offset) + "): ");
 
         for (uint32_t x = 0; x < index_count_total; x++) {
-            std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
-            std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+            std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
+            std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
             prim_position += 0x2;
 
             indexes.push_back(bytes2);
@@ -1157,20 +1143,20 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex (32bit float): ");
 
-                std::memcpy(&temp_vector4.x, &prim_data.data()[prim_position], sizeof(bytes4));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes4_zero, sizeof(bytes4));
+                std::memcpy(&temp_vector4.x, &prim_data[prim_position], BYTES4);
+                std::memcpy(&prim_meta_data[prim_position], &bytes4_zero, BYTES4);
                 prim_position += 0x4;
 
                 //LOG("              - x: " + util::float_to_string(temp_vector4.x));
 
-                std::memcpy(&temp_vector4.y, &prim_data.data()[prim_position], sizeof(bytes4));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes4_zero, sizeof(bytes4));
+                std::memcpy(&temp_vector4.y, &prim_data[prim_position], BYTES4);
+                std::memcpy(&prim_meta_data[prim_position], &bytes4_zero, BYTES4);
                 prim_position += 0x4;
 
                 //LOG("              - y: " + util::float_to_string(temp_vector4.y));
 
-                std::memcpy(&temp_vector4.z, &prim_data.data()[prim_position], sizeof(bytes4));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes4_zero, sizeof(bytes4));
+                std::memcpy(&temp_vector4.z, &prim_data[prim_position], BYTES4);
+                std::memcpy(&prim_meta_data[prim_position], &bytes4_zero, BYTES4);
                 prim_position += 0x4;
 
                 //LOG("              - z: " + util::float_to_string(temp_vector4.z));
@@ -1187,8 +1173,8 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex compressed (short): ");
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - x: " + util::short_to_string(temp_short));
@@ -1196,8 +1182,8 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
                 temp_vector4.x = (static_cast<float>(temp_short) * temp_prim_mesh.vertex_position_scale.x) /
                                  std::numeric_limits<short>::max() + temp_prim_mesh.vertex_position_bias.x;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - y: " + util::short_to_string(temp_short));
@@ -1205,8 +1191,8 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
                 temp_vector4.y = (static_cast<float>(temp_short) * temp_prim_mesh.vertex_position_scale.y) /
                                  std::numeric_limits<short>::max() + temp_prim_mesh.vertex_position_bias.y;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - z: " + util::short_to_string(temp_short));
@@ -1214,8 +1200,8 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
                 temp_vector4.z = (static_cast<float>(temp_short) * temp_prim_mesh.vertex_position_scale.z) /
                                  std::numeric_limits<short>::max() + temp_prim_mesh.vertex_position_bias.z;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - w: " + util::short_to_string(temp_short));
@@ -1237,275 +1223,275 @@ prim::prim_sub_mesh::prim_sub_mesh(std::vector<char>& prim_data, uint32_t& prim_
             }
         }
 
-        if (1)//if (prim_object_sub_type.at(o) != 0x2)
-        {
-            for (uint32_t v = 0; v < vertex_count; v++) {
-                vector4 temp_vector4;
+//        if (1)//if (prim_object_sub_type.at(o) != 0x2)
+//        {
+        for (uint32_t v = 0; v < vertex_count; v++) {
+            vector4 temp_vector4;
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex normal compressed (uint8_t):");
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex normal compressed (uint8_t):");
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - w: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - w: " + util::uint8_t_to_hex_string(bytes1));
 
-                vertexes_normals.push_back(temp_vector4.x);
-                vertexes_normals.push_back(temp_vector4.y);
-                vertexes_normals.push_back(temp_vector4.z);
+            vertexes_normals.push_back(temp_vector4.x);
+            vertexes_normals.push_back(temp_vector4.y);
+            vertexes_normals.push_back(temp_vector4.z);
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex normal decompressed (float):");
-                //LOG("              - x: " + util::float_to_string(temp_vector4.x));
-                //LOG("              - y: " + util::float_to_string(temp_vector4.y));
-                //LOG("              - z: " + util::float_to_string(temp_vector4.z));
-                //LOG("              - w: " + util::float_to_string(temp_vector4.w));
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex normal decompressed (float):");
+            //LOG("              - x: " + util::float_to_string(temp_vector4.x));
+            //LOG("              - y: " + util::float_to_string(temp_vector4.y));
+            //LOG("              - z: " + util::float_to_string(temp_vector4.z));
+            //LOG("              - w: " + util::float_to_string(temp_vector4.w));
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex tangents compressed (uint8_t):");
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex tangents compressed (uint8_t):");
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - w: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - w: " + util::uint8_t_to_hex_string(bytes1));
 
-                vertexes_tangents.push_back(temp_vector4.x);
-                vertexes_tangents.push_back(temp_vector4.y);
-                vertexes_tangents.push_back(temp_vector4.z);
-                vertexes_tangents.push_back(temp_vector4.w);
+            vertexes_tangents.push_back(temp_vector4.x);
+            vertexes_tangents.push_back(temp_vector4.y);
+            vertexes_tangents.push_back(temp_vector4.z);
+            vertexes_tangents.push_back(temp_vector4.w);
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex tangents decompressed (float):");
-                //LOG("              - x: " + util::float_to_string(temp_vector4.x));
-                //LOG("              - y: " + util::float_to_string(temp_vector4.y));
-                //LOG("              - z: " + util::float_to_string(temp_vector4.z));
-                //LOG("              - w: " + util::float_to_string(temp_vector4.w));
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex tangents decompressed (float):");
+            //LOG("              - x: " + util::float_to_string(temp_vector4.x));
+            //LOG("              - y: " + util::float_to_string(temp_vector4.y));
+            //LOG("              - z: " + util::float_to_string(temp_vector4.z));
+            //LOG("              - w: " + util::float_to_string(temp_vector4.w));
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex bitangents compressed (uint8_t):");
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex bitangents compressed (uint8_t):");
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                prim_position += 0x1;
+            std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+            std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+            prim_position += 0x1;
 
-                temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
+            temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
-                //LOG("              - w: " + util::uint8_t_to_hex_string(bytes1));
+            //LOG("              - w: " + util::uint8_t_to_hex_string(bytes1));
 
-                vertexes_bitangents.push_back(temp_vector4.x);
-                vertexes_bitangents.push_back(temp_vector4.y);
-                vertexes_bitangents.push_back(temp_vector4.z);
+            vertexes_bitangents.push_back(temp_vector4.x);
+            vertexes_bitangents.push_back(temp_vector4.y);
+            vertexes_bitangents.push_back(temp_vector4.z);
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex bitangents decompressed (float):");
-                //LOG("              - x: " + util::float_to_string(temp_vector4.x));
-                //LOG("              - y: " + util::float_to_string(temp_vector4.y));
-                //LOG("              - z: " + util::float_to_string(temp_vector4.z));
-                //LOG("              - w: " + util::float_to_string(temp_vector4.w));
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex bitangents decompressed (float):");
+            //LOG("              - x: " + util::float_to_string(temp_vector4.x));
+            //LOG("              - y: " + util::float_to_string(temp_vector4.y));
+            //LOG("              - z: " + util::float_to_string(temp_vector4.z));
+            //LOG("              - w: " + util::float_to_string(temp_vector4.w));
 
-                short temp_short = 0;
+            short temp_short = 0;
 
-                vector2 temp_vector2;
+            vector2 temp_vector2;
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex uv compressed (short): ");
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex uv compressed (short): ");
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
-                prim_position += 0x2;
+            std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+            std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
+            prim_position += 0x2;
 
-                //LOG("              - x: " + util::short_to_string(temp_short));
+            //LOG("              - x: " + util::short_to_string(temp_short));
 
-                temp_vector2.x = (static_cast<float>(temp_short) * temp_prim_mesh.uv_position_scale.x) /
-                                 std::numeric_limits<short>::max() + temp_prim_mesh.uv_position_bias.x;
+            temp_vector2.x = (static_cast<float>(temp_short) * temp_prim_mesh.uv_position_scale.x) /
+                             std::numeric_limits<short>::max() + temp_prim_mesh.uv_position_bias.x;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
-                prim_position += 0x2;
+            std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+            std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
+            prim_position += 0x2;
 
-                //LOG("              - y: " + util::short_to_string(temp_short));
+            //LOG("              - y: " + util::short_to_string(temp_short));
 
-                temp_vector2.y = (static_cast<float>(temp_short) * temp_prim_mesh.uv_position_scale.y) /
-                                 std::numeric_limits<short>::max() + temp_prim_mesh.uv_position_bias.y;
+            temp_vector2.y = (static_cast<float>(temp_short) * temp_prim_mesh.uv_position_scale.y) /
+                             std::numeric_limits<short>::max() + temp_prim_mesh.uv_position_bias.y;
 
-                vertexes_uvs.push_back(temp_vector2.x);
-                vertexes_uvs.push_back(temp_vector2.y);
+            vertexes_uvs.push_back(temp_vector2.x);
+            vertexes_uvs.push_back(temp_vector2.y);
 
-                //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex uv decompressed (float):");
-                //LOG("              - x: " + util::float_to_string(temp_vector2.x));
-                //LOG("              - y: " + util::float_to_string(temp_vector2.y));
-            }
-
-            if (temp_prim_mesh.prim_object_instance.sub_type == (uint32_t) prim_object::SUBTYPE::WEIGHTED ||
-                ((prim_object_instance.property_flags & (uint32_t) prim_object::PROPERTY_FLAGS::COLOR1) == 0x0)) {
-                for (uint32_t v = 0; v < vertex_count; v++) {
-                    rgba temp_rgba;
-
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                    prim_position += 0x1;
-
-                    //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color r: " + util::uint8_t_to_hex_string(bytes1));
-
-                    temp_rgba.r = bytes1;
-
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                    prim_position += 0x1;
-
-                    //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color g: " + util::uint8_t_to_hex_string(bytes1));
-
-                    temp_rgba.g = bytes1;
-
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                    prim_position += 0x1;
-
-                    //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color b: " + util::uint8_t_to_hex_string(bytes1));
-
-                    temp_rgba.b = bytes1;
-
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
-                    prim_position += 0x1;
-
-                    //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color a: " + util::uint8_t_to_hex_string(bytes1));
-
-                    temp_rgba.a = bytes1;
-
-                    vertexes_colors.push_back(temp_rgba.r);
-                    vertexes_colors.push_back(temp_rgba.g);
-                    vertexes_colors.push_back(temp_rgba.b);
-                    vertexes_colors.push_back(temp_rgba.a);
-                }
-            }
-
-            if (cloth_offset) {
-                prim_position = cloth_offset;
-
-                if ((temp_prim_mesh.cloth_flags & (uint32_t) prim_mesh::CLOTH_FLAGS::SMALL) ==
-                    (uint32_t) prim_mesh::CLOTH_FLAGS::SMALL) {
-                    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
-
-                    uint32_t cloth_data_size = bytes2;
-
-                    cloth_data.resize(cloth_data_size);
-
-                    std::memcpy(cloth_data.data(), &prim_data.data()[prim_position], cloth_data_size);
-                } else {
-                    uint32_t cloth_data_size = vertex_count * 0x14;
-
-                    cloth_data.resize(cloth_data_size);
-
-                    std::memcpy(cloth_data.data(), &prim_data.data()[prim_position], cloth_data_size);
-                }
-            }
-
-            if (collision_offset) {
-                prim_position = collision_offset;
-
-                if (temp_prim_mesh.prim_object_instance.sub_type == (uint32_t) prim_object::SUBTYPE::STANDARD ||
-                    temp_prim_mesh.prim_object_instance.sub_type == (uint32_t) prim_object::SUBTYPE::WEIGHTED) {
-                    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
-
-                    uint32_t collision_data_size = bytes2;
-
-                    collision_data_size *= 6;
-                    collision_data_size += 4;
-
-                    collision_data.resize(collision_data_size);
-
-                    std::memcpy(collision_data.data(), &prim_data.data()[prim_position], collision_data_size);
-                } else {
-                    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
-
-                    uint32_t collision_data_size = bytes2;
-
-                    collision_data.resize(collision_data_size);
-
-                    std::memcpy(collision_data.data(), &prim_data.data()[prim_position], collision_data_size);
-                }
-            }
-        } else {
-            //LOG("Error: PRIM_OBJECT_IS_NOT_A_MESH_TYPE");
-
-            task_multiple_status = PRIM_OBJECT_IS_NOT_A_MESH_TYPE;
-
-            success = false;
-
-            //return;
+            //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex uv decompressed (float):");
+            //LOG("              - x: " + util::float_to_string(temp_vector2.x));
+            //LOG("              - y: " + util::float_to_string(temp_vector2.y));
         }
+
+        if (temp_prim_mesh.prim_object_instance.sub_type == (uint32_t) prim_object::SUBTYPE::WEIGHTED ||
+            ((prim_object_instance.property_flags & (uint32_t) prim_object::PROPERTY_FLAGS::COLOR1) == 0x0)) {
+            for (uint32_t v = 0; v < vertex_count; v++) {
+                rgba temp_rgba;
+
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+                prim_position += 0x1;
+
+                //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color r: " + util::uint8_t_to_hex_string(bytes1));
+
+                temp_rgba.r = bytes1;
+
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+                prim_position += 0x1;
+
+                //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color g: " + util::uint8_t_to_hex_string(bytes1));
+
+                temp_rgba.g = bytes1;
+
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+                prim_position += 0x1;
+
+                //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color b: " + util::uint8_t_to_hex_string(bytes1));
+
+                temp_rgba.b = bytes1;
+
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
+                prim_position += 0x1;
+
+                //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color a: " + util::uint8_t_to_hex_string(bytes1));
+
+                temp_rgba.a = bytes1;
+
+                vertexes_colors.push_back(temp_rgba.r);
+                vertexes_colors.push_back(temp_rgba.g);
+                vertexes_colors.push_back(temp_rgba.b);
+                vertexes_colors.push_back(temp_rgba.a);
+            }
+        }
+
+        if (cloth_offset) {
+            prim_position = cloth_offset;
+
+            if ((temp_prim_mesh.cloth_flags & (uint32_t) prim_mesh::CLOTH_FLAGS::SMALL) ==
+                (uint32_t) prim_mesh::CLOTH_FLAGS::SMALL) {
+                std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
+
+                uint32_t cloth_data_size = bytes2;
+
+                cloth_data.resize(cloth_data_size);
+
+                std::memcpy(cloth_data.data(), &prim_data[prim_position], cloth_data_size);
+            } else {
+                uint32_t cloth_data_size = vertex_count * 0x14;
+
+                cloth_data.resize(cloth_data_size);
+
+                std::memcpy(cloth_data.data(), &prim_data[prim_position], cloth_data_size);
+            }
+        }
+
+        if (collision_offset) {
+            prim_position = collision_offset;
+
+            if (temp_prim_mesh.prim_object_instance.sub_type == (uint32_t) prim_object::SUBTYPE::STANDARD ||
+                temp_prim_mesh.prim_object_instance.sub_type == (uint32_t) prim_object::SUBTYPE::WEIGHTED) {
+                std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
+
+                uint32_t collision_data_size = bytes2;
+
+                collision_data_size *= 6;
+                collision_data_size += 4;
+
+                collision_data.resize(collision_data_size);
+
+                std::memcpy(collision_data.data(), &prim_data[prim_position], collision_data_size);
+            } else {
+                std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
+
+                uint32_t collision_data_size = bytes2;
+
+                collision_data.resize(collision_data_size);
+
+                std::memcpy(collision_data.data(), &prim_data[prim_position], collision_data_size);
+            }
+        }
+//        } else {
+//            //LOG("Error: PRIM_OBJECT_IS_NOT_A_MESH_TYPE");
+//
+//            task_multiple_status = PRIM_OBJECT_IS_NOT_A_MESH_TYPE;
+//
+//            success = false;
+//
+//            //return;
+//        }
     } else {
         //LOG("Error: PRIM_UV_CHANNEL_COUNT_GREATER_THAN_1");
 
@@ -1537,47 +1523,47 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
     uint32_t object = prim_object_number;
 
-    std::memcpy(&vertex_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex count: " + util::uint32_t_to_hex_string(vertex_count));
 
-    std::memcpy(&vertex_buffer_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&vertex_buffer_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex buffer offset: " + util::uint32_t_to_hex_string(vertex_buffer_offset));
 
-    std::memcpy(&index_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&index_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh index count: " + util::uint32_t_to_hex_string(index_count));
 
-    std::memcpy(&index_count_additional, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&index_count_additional, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh index count additional: " + util::uint32_t_to_hex_string(index_count_additional));
 
-    std::memcpy(&index_buffer_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&index_buffer_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh index buffer offset: " + util::uint32_t_to_hex_string(index_buffer_offset));
 
-    std::memcpy(&collision_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&collision_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh collision offset: " + util::uint32_t_to_hex_string(collision_offset));
 
-    std::memcpy(&cloth_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&cloth_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh cloth offset: " + util::uint32_t_to_hex_string(cloth_offset));
 
-    std::memcpy(&uv_channel_count, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&uv_channel_count, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh uv channel count: " + util::uint32_t_to_hex_string(uv_channel_count));
 
-    std::memcpy(&unknown_offset, &prim_data.data()[prim_position], sizeof(bytes4));
+    std::memcpy(&unknown_offset, &prim_data[prim_position], BYTES4);
     prim_position += 0x4;
 
     //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh unknown offset: " + util::uint32_t_to_hex_string(unknown_offset));
@@ -1590,8 +1576,8 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
         //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh indexes at (" + util::uint32_t_to_hex_string(index_buffer_offset) + "): ");
 
         for (uint32_t x = 0; x < index_count_total; x++) {
-            std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
-            std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+            std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
+            std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
             prim_position += 0x2;
 
             indexes.push_back(bytes2);
@@ -1607,20 +1593,20 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex (32bit float): ");
 
-                std::memcpy(&temp_vector4.x, &prim_data.data()[prim_position], sizeof(bytes4));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes4_zero, sizeof(bytes4));
+                std::memcpy(&temp_vector4.x, &prim_data[prim_position], BYTES4);
+                std::memcpy(&prim_meta_data[prim_position], &bytes4_zero, BYTES4);
                 prim_position += 0x4;
 
                 //LOG("              - x: " + util::float_to_string(temp_vector4.x));
 
-                std::memcpy(&temp_vector4.y, &prim_data.data()[prim_position], sizeof(bytes4));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes4_zero, sizeof(bytes4));
+                std::memcpy(&temp_vector4.y, &prim_data[prim_position], BYTES4);
+                std::memcpy(&prim_meta_data[prim_position], &bytes4_zero, BYTES4);
                 prim_position += 0x4;
 
                 //LOG("              - y: " + util::float_to_string(temp_vector4.y));
 
-                std::memcpy(&temp_vector4.z, &prim_data.data()[prim_position], sizeof(bytes4));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes4_zero, sizeof(bytes4));
+                std::memcpy(&temp_vector4.z, &prim_data[prim_position], BYTES4);
+                std::memcpy(&prim_meta_data[prim_position], &bytes4_zero, BYTES4);
                 prim_position += 0x4;
 
                 //LOG("              - z: " + util::float_to_string(temp_vector4.z));
@@ -1637,8 +1623,8 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex compressed (short): ");
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - x: " + util::short_to_string(temp_short));
@@ -1648,8 +1634,8 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                                  std::numeric_limits<short>::max() +
                                  temp_weighted_prim_mesh.prim_mesh_instance.vertex_position_bias.x;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - y: " + util::short_to_string(temp_short));
@@ -1659,8 +1645,8 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                                  std::numeric_limits<short>::max() +
                                  temp_weighted_prim_mesh.prim_mesh_instance.vertex_position_bias.y;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - z: " + util::short_to_string(temp_short));
@@ -1670,8 +1656,8 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                                  std::numeric_limits<short>::max() +
                                  temp_weighted_prim_mesh.prim_mesh_instance.vertex_position_bias.z;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - w: " + util::short_to_string(temp_short));
@@ -1700,56 +1686,56 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
             for (uint32_t v = 0; v < vertex_count; v++) {
                 vector6 temp_vector6;
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector6.a = static_cast<float>(bytes1) / 255.0f;
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector6.b = static_cast<float>(bytes1) / 255.0f;
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector6.c = static_cast<float>(bytes1) / 255.0f;
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector6.d = static_cast<float>(bytes1) / 255.0f;
 
                 uint8_t_6 temp_uint8_t_6;
 
-                std::memcpy(&temp_uint8_t_6.a, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&temp_uint8_t_6.a, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
-                std::memcpy(&temp_uint8_t_6.b, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&temp_uint8_t_6.b, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
-                std::memcpy(&temp_uint8_t_6.c, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&temp_uint8_t_6.c, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
-                std::memcpy(&temp_uint8_t_6.d, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&temp_uint8_t_6.d, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector6.e = static_cast<float>(bytes1) / 255.0f;
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector6.f = static_cast<float>(bytes1) / 255.0f;
@@ -1771,12 +1757,12 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                 vertexes_weighted_weights_1.push_back(0x0);
                 vertexes_weighted_weights_1.push_back(0x0);
 
-                std::memcpy(&temp_uint8_t_6.e, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&temp_uint8_t_6.e, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
-                std::memcpy(&temp_uint8_t_6.f, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&temp_uint8_t_6.f, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh weighted vertex bone_ids: ");
@@ -1805,32 +1791,32 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex normal compressed (uint8_t):");
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
@@ -1849,32 +1835,32 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex tangents compressed (uint8_t):");
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
@@ -1894,32 +1880,32 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex bitangents compressed (uint8_t):");
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.x = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - x: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.y = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - y: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.z = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
 
                 //LOG("              - z: " + util::uint8_t_to_hex_string(bytes1));
 
-                std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                 prim_position += 0x1;
 
                 temp_vector4.w = ((2.0f * static_cast<float>(bytes1)) / 255.0f) - 1.0f;
@@ -1942,8 +1928,8 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                 //LOG("          - PRIM object (" + std::to_string(object) + ") sub mesh vertex uv compressed (short): ");
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - x: " + util::short_to_string(temp_short));
@@ -1953,8 +1939,8 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                                  std::numeric_limits<short>::max() +
                                  temp_weighted_prim_mesh.prim_mesh_instance.uv_position_bias.x;
 
-                std::memcpy(&temp_short, &prim_data.data()[prim_position], sizeof(bytes2));
-                std::memcpy(&prim_meta_data.data()[prim_position], &bytes2_zero, sizeof(bytes2));
+                std::memcpy(&temp_short, &prim_data[prim_position], BYTES2);
+                std::memcpy(&prim_meta_data[prim_position], &bytes2_zero, BYTES2);
                 prim_position += 0x2;
 
                 //LOG("              - y: " + util::short_to_string(temp_short));
@@ -1978,32 +1964,32 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                 for (uint32_t v = 0; v < vertex_count; v++) {
                     rgba temp_rgba;
 
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                    std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                     prim_position += 0x1;
 
                     //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color r: " + util::uint8_t_to_hex_string(bytes1));
 
                     temp_rgba.r = bytes1;
 
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                    std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                     prim_position += 0x1;
 
                     //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color g: " + util::uint8_t_to_hex_string(bytes1));
 
                     temp_rgba.g = bytes1;
 
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                    std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                     prim_position += 0x1;
 
                     //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color b: " + util::uint8_t_to_hex_string(bytes1));
 
                     temp_rgba.b = bytes1;
 
-                    std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
-                    std::memcpy(&prim_meta_data.data()[prim_position], &bytes1_zero, sizeof(bytes1));
+                    std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
+                    std::memcpy(&prim_meta_data[prim_position], &bytes1_zero, BYTES1);
                     prim_position += 0x1;
 
                     //LOG("      - PRIM object (" + std::to_string(object) + ") sub mesh vertex color a: " + util::uint8_t_to_hex_string(bytes1));
@@ -2022,19 +2008,19 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                 if ((temp_weighted_prim_mesh.prim_mesh_instance.cloth_flags &
                      (uint32_t) prim_mesh::CLOTH_FLAGS::SMALL) == (uint32_t) prim_mesh::CLOTH_FLAGS::SMALL) {
-                    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
+                    std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
 
                     uint32_t cloth_data_size = bytes2;
 
                     cloth_data.resize(cloth_data_size);
 
-                    std::memcpy(cloth_data.data(), &prim_data.data()[prim_position], cloth_data_size);
+                    std::memcpy(cloth_data.data(), &prim_data[prim_position], cloth_data_size);
                 } else {
                     uint32_t cloth_data_size = vertex_count * 0x14;
 
                     cloth_data.resize(cloth_data_size);
 
-                    std::memcpy(cloth_data.data(), &prim_data.data()[prim_position], cloth_data_size);
+                    std::memcpy(cloth_data.data(), &prim_data[prim_position], cloth_data_size);
                 }
             }
 
@@ -2045,7 +2031,7 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                     (uint32_t) prim_object::SUBTYPE::STANDARD ||
                     temp_weighted_prim_mesh.prim_mesh_instance.prim_object_instance.sub_type ==
                     (uint32_t) prim_object::SUBTYPE::WEIGHTED) {
-                    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
+                    std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
 
                     uint32_t collision_data_size = bytes2;
 
@@ -2054,15 +2040,15 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
 
                     collision_data.resize(collision_data_size);
 
-                    std::memcpy(collision_data.data(), &prim_data.data()[prim_position], collision_data_size);
+                    std::memcpy(collision_data.data(), &prim_data[prim_position], collision_data_size);
                 } else {
-                    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
+                    std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
 
                     uint32_t collision_data_size = bytes2;
 
                     collision_data.resize(collision_data_size);
 
-                    std::memcpy(collision_data.data(), &prim_data.data()[prim_position], collision_data_size);
+                    std::memcpy(collision_data.data(), &prim_data[prim_position], collision_data_size);
                 }
             }
 
@@ -2074,7 +2060,7 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                     uint32_t bones_nodes_data_size = temp_weighted_prim_mesh.bones_nodes_count * 2;
 
                     for (uint32_t b = 0; b < bones_nodes_data_size; b++) {
-                        std::memcpy(&bytes4, &prim_data.data()[prim_position], sizeof(bytes4));
+                        std::memcpy(&bytes4, &prim_data[prim_position], BYTES4);
                         prim_position += 0x4;
 
                         bones_nodes_data.push_back(bytes4);
@@ -2084,12 +2070,12 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                 if (temp_weighted_prim_mesh.bone_info_offset) {
                     prim_position = temp_weighted_prim_mesh.bone_info_offset;
 
-                    std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
+                    std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
 
                     uint32_t bone_info_data_size = bytes2;
 
                     for (uint32_t b = 0; b < bone_info_data_size; b++) {
-                        std::memcpy(&bytes1, &prim_data.data()[prim_position], sizeof(bytes1));
+                        std::memcpy(&bytes1, &prim_data[prim_position], BYTES1);
                         prim_position += 0x1;
 
                         bones_info_data.push_back(bytes1);
@@ -2099,14 +2085,14 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
                 if (temp_weighted_prim_mesh.bone_indices_offset) {
                     prim_position = temp_weighted_prim_mesh.bone_indices_offset;
 
-                    std::memcpy(&bytes4, &prim_data.data()[prim_position], sizeof(bytes4));
+                    std::memcpy(&bytes4, &prim_data[prim_position], BYTES4);
                     prim_position += 0x4;
 
                     uint32_t bone_indices_data_size = bytes4;
                     bone_indices_data_size -= 2;
 
                     for (uint32_t b = 0; b < bone_indices_data_size; b++) {
-                        std::memcpy(&bytes2, &prim_data.data()[prim_position], sizeof(bytes2));
+                        std::memcpy(&bytes2, &prim_data[prim_position], BYTES2);
                         prim_position += 0x2;
 
                         bones_indices_data.push_back(bytes2);
@@ -2133,7 +2119,7 @@ prim::prim_weighted_sub_mesh::prim_weighted_sub_mesh(std::vector<char>& prim_dat
     }
 }
 
-void prim::extract_meta(std::string output_path) {
+void prim::extract_meta(const std::string& output_path) {
     char char4[4];
 
     std::string prim_meta_file_name = file::output_path_append(prim_file_name + ".glb.meta", output_path);

--- a/src/prim.h
+++ b/src/prim.h
@@ -14,7 +14,7 @@ public:
 
     void load_hash_depends();
 
-    void extract_meta(std::string output_path);
+    void extract_meta(const std::string& output_path);
 
     class prim_header {
     public:

--- a/src/rpkg_function.h
+++ b/src/rpkg_function.h
@@ -39,7 +39,7 @@ public:
 
     static void search_repo(std::string& input_path, std::string& search, int max_results);
 
-    static void sdef_to_json(std::string& input_path, std::string& filter, std::string& output_path);
+    static void sdef_to_json(std::string& input_path, std::string& output_path);
 
     static void json_to_sdef(std::string& input_path, std::string& output_path);
 
@@ -125,7 +125,7 @@ public:
 
     static int load_temp_tblu_hash_depends(uint64_t rpkg_index, uint64_t hash_index);
 
-    static void extract_temp_from(std::string& input_path, std::string& filter, std::string& output_path);
+//    static void extract_temp_from(std::string& input_path, std::string& filter, std::string& output_path);
 
     static void extract_prel_refs(std::string& input_path);
 

--- a/src/sdef_to_json.cpp
+++ b/src/sdef_to_json.cpp
@@ -7,53 +7,58 @@
 #include <iostream>
 #include <filesystem>
 
-void rpkg_function::sdef_to_json(std::string& input_path, std::string& filter, std::string& output_path) {
+void rpkg_function::sdef_to_json(std::string& input_path, std::string& output_path) {
     task_single_status = TASK_EXECUTING;
     task_multiple_status = TASK_EXECUTING;
 
     log_output = false;
 
-    if (file::path_exists(input_path)) {
-        bool output_path_is_file = false;
+    if (!file::path_exists(input_path)) {
+        log_output = true;
 
-        std::vector<std::filesystem::path> files;
+        task_single_status = TASK_SUCCESSFUL;
+        task_multiple_status = TASK_SUCCESSFUL;
 
-        if (std::filesystem::is_regular_file(input_path)) {
-            files.push_back(std::filesystem::path(input_path));
+        return;
+    }
 
-            if (output_path != "") {
-                if (std::filesystem::exists(output_path)) {
-                    if (std::filesystem::is_regular_file(output_path)) {
-                        output_path_is_file = true;
-                    }
-                } else {
+    bool output_path_is_file = false;
+
+    std::vector<std::filesystem::path> files;
+
+    if (std::filesystem::is_regular_file(input_path)) {
+        files.emplace_back(input_path);
+
+        if (!output_path.empty()) {
+            if (std::filesystem::exists(output_path)) {
+                if (std::filesystem::is_regular_file(output_path)) {
                     output_path_is_file = true;
                 }
+            } else {
+                output_path_is_file = true;
             }
-        } else {
-            files = file::get_recursive_file_list(input_path);
         }
+    } else {
+        files = file::get_recursive_file_list(input_path);
+    }
 
-        LOG("Loading Hash List...");
-        generic_function::load_hash_list(true);
-        LOG("Loading Hash List: Done");
+    force_load_hash_list();
 
-        for (std::filesystem::path& file : files) {
-            uint64_t hash_value = file::get_hash_value_from_path(file, ".SDEF");
+    for (std::filesystem::path& file : files) {
+        uint64_t hash_value = file::get_hash_value_from_path(file, ".SDEF");
 
-            if (hash_value) {
-                if (file::path_exists(file.string() + ".meta")) {
-                    timing_string = "Converting: " + file.filename().string() + " (+ SDEF.meta) to SDEF JSON";
+        if (hash_value) {
+            if (file::path_exists(file.string() + ".meta")) {
+                timing_string = "Converting: " + file.filename().string() + " (+ SDEF.meta) to SDEF JSON";
 
-                    LOG(timing_string);
+                LOG(timing_string);
 
-                    if (output_path == "") {
-                        sdef temp_sdef(file.string(), file.string() + ".meta", hash_value, file.parent_path().string(),
-                                       output_path_is_file);
-                    } else {
-                        sdef temp_sdef(file.string(), file.string() + ".meta", hash_value, output_path,
-                                       output_path_is_file);
-                    }
+                if (output_path.empty()) {
+                    sdef temp_sdef(file.string(), file.string() + ".meta", hash_value, file.parent_path().string(),
+                                   output_path_is_file);
+                } else {
+                    sdef temp_sdef(file.string(), file.string() + ".meta", hash_value, output_path,
+                                   output_path_is_file);
                 }
             }
         }

--- a/src/search_entities.cpp
+++ b/src/search_entities.cpp
@@ -27,33 +27,32 @@ void rpkg_function::search_entities(std::string& input_path, std::string& search
     for (uint64_t i = 0; i < rpkgs.size(); i++) {
         std::string message = "Searching " + rpkgs.at(i).rpkg_file_name + "...";
 
-        if (input_path.empty() || input_path == rpkgs.at(i).rpkg_file_path) {
-            for (uint64_t r = 0; r < rpkgs.at(i).hash_resource_types.size(); r++) {
-                if (gui_control == ABORT_CURRENT_TASK) {
-                    return;
-                }
+        if (!input_path.empty() && input_path != rpkgs.at(i).rpkg_file_path) continue;
 
-                if (rpkgs.at(i).hash_resource_types.at(r) == "TEMP") {
-                    for (uint64_t j = 0; j < rpkgs.at(i).hashes_indexes_based_on_resource_types.at(r).size(); j++) {
-                        uint64_t hash_index = rpkgs.at(i).hashes_indexes_based_on_resource_types.at(r).at(j);
+        for (uint64_t r1 = 0; r1 < rpkgs.at(i).hash_resource_types.size(); r1++) {
+            if (gui_control == ABORT_CURRENT_TASK) {
+                return;
+            }
 
-                        uint64_t temp_hash_value = rpkgs.at(i).hash.at(hash_index).hash_value;
+            if (rpkgs.at(i).hash_resource_types.at(r1) == "TEMP") {
+                for (uint64_t j = 0; j < rpkgs.at(i).hashes_indexes_based_on_resource_types.at(r1).size(); j++) {
+                    uint64_t hash_index = rpkgs.at(i).hashes_indexes_based_on_resource_types.at(r1).at(j);
 
-                        uint32_t rpkg_index = rpkg_function::get_latest_hash(temp_hash_value);
+                    uint64_t temp_hash_value = rpkgs.at(i).hash.at(hash_index).hash_value;
 
-                        if (rpkg_index == UINT32_MAX)
-                            continue;
+                    uint32_t rpkg_index = rpkg_function::get_latest_hash(temp_hash_value);
 
-                        if (!input_path.empty() && input_path != rpkgs.at(rpkg_index).rpkg_file_path)
-                            continue;
+                    if (rpkg_index == UINT32_MAX)
+                        continue;
 
-                        auto it6 = rpkgs.at(rpkg_index).hash_map.find(temp_hash_value);
+                    if (!input_path.empty() && input_path != rpkgs.at(rpkg_index).rpkg_file_path)
+                        continue;
 
-                        if (it6 != rpkgs.at(rpkg_index).hash_map.end()) {
-                            entities_hash_size_total += rpkgs.at(rpkg_index).hash.at(
-                                    it6->second).data.resource.size_final;
-                            entities_hash_count++;
-                        }
+                    auto it6 = rpkgs.at(rpkg_index).hash_map.find(temp_hash_value);
+
+                    if (it6 != rpkgs.at(rpkg_index).hash_map.end()) {
+                        entities_hash_size_total += rpkgs.at(rpkg_index).hash.at(it6->second).data.resource.size_final;
+                        entities_hash_count++;
                     }
                 }
             }
@@ -65,13 +64,13 @@ void rpkg_function::search_entities(std::string& input_path, std::string& search
 
     std::unordered_map<uint64_t, uint64_t> hash_searched;
 
-    std::string search_lower_case = util::to_lower_case(search);
+    const std::string search_lower_case = util::to_lower_case(search);
 
     std::chrono::time_point start_time = std::chrono::high_resolution_clock::now();
     int stringstream_length = 80;
 
     for (uint64_t i = 0; i < rpkgs.size(); i++) {
-        std::string message = "Searching " + rpkgs.at(i).rpkg_file_name + "...";
+        const std::string message = "Searching " + rpkgs.at(i).rpkg_file_name + "...";
 
         if (input_path.empty() || input_path == rpkgs.at(i).rpkg_file_path) {
             for (uint64_t r = 0; r < rpkgs.at(i).hash_resource_types.size(); r++) {
@@ -162,9 +161,4 @@ void rpkg_function::search_entities(std::string& input_path, std::string& search
 
     task_single_status = TASK_SUCCESSFUL;
     task_multiple_status = TASK_SUCCESSFUL;
-    /*}
-    else
-    {
-        LOG_AND_EXIT("Error: The folder " + input_path + " to with the input RPKGs does not exist.");
-    }*/
 }

--- a/src/search_hash_data.cpp
+++ b/src/search_hash_data.cpp
@@ -107,7 +107,7 @@ void rpkg_function::search_hash_data(std::string& search_type, std::string& sear
         while (std::regex_search(data_string, m, re)) {
             position += m.position();
 
-            LOG("Regex search with regex \"" << search << "\" returned result in hash file/resouce " << hash_file_name);
+            LOG("Regex search with regex \"" << search << "\" returned result in hash file/resource " << hash_file_name);
 
             for (size_t k = 0; k < m.size(); k++) {
                 LOG("Match[" << k << "]: " << m[k].str());

--- a/src/search_repo.cpp
+++ b/src/search_repo.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <chrono>
 #include <sstream>
-#include <regex>
 #include <filesystem>
 
 void rpkg_function::search_repo(std::string& input_path, std::string& search, int max_results) {
@@ -21,30 +20,28 @@ void rpkg_function::search_repo(std::string& input_path, std::string& search, in
         rpkg_function::import_rpkg_files_in_folder(input_path);
     }
 
-    uint32_t results_count = 0;
-
-    std::string search_lower_case = util::to_lower_case(search);
+    const std::string search_lower_case = util::to_lower_case(search);
 
     // uint32_t search_crc32_dec = std::strtoul(search.c_str(), nullptr, 10);
 
     // uint32_t search_crc32_hex = std::strtoul(search.c_str(), nullptr, 16);
 
-    std::chrono::time_point start_time = std::chrono::high_resolution_clock::now();
+    const std::chrono::time_point start_time = std::chrono::high_resolution_clock::now();
     // int stringstream_length = 80;
 
-    std::string message = "Searching REPO (00204D1AFD76AB13)...";
+    const std::string message = "Searching REPO (00204D1AFD76AB13)...";
 
-    uint64_t repo_hash_value = 0x00204D1AFD76AB13;
+    constexpr uint64_t repo_hash_value = 0x00204D1AFD76AB13;
 
-    uint32_t repo_rpkg_index = rpkg_function::get_latest_hash(repo_hash_value);
+    const uint32_t repo_rpkg_index = rpkg_function::get_latest_hash(repo_hash_value);
 
     if (repo_rpkg_index != UINT32_MAX) {
         const auto it = rpkgs.at(repo_rpkg_index).hash_map.find(repo_hash_value);
 
         if (it != rpkgs.at(repo_rpkg_index).hash_map.end()) {
-            uint64_t ores_hash_value = 0x00858D45F5F9E3CA;
+            constexpr uint64_t ores_hash_value = 0x00858D45F5F9E3CA;
 
-            uint32_t ores_rpkg_index = rpkg_function::get_latest_hash(ores_hash_value);
+            const uint32_t ores_rpkg_index = rpkg_function::get_latest_hash(ores_hash_value);
 
             if (ores_rpkg_index != UINT32_MAX) {
                 auto it2 = rpkgs.at(ores_rpkg_index).hash_map.find(ores_hash_value);

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -177,7 +177,7 @@ void task::execute(std::string& command, std::string& input_path, std::string& f
     } else if (command == "-json_to_sdef") {
         rpkg_function::json_to_sdef(input_path, output_path);
     } else if (command == "-sdef_to_json") {
-        rpkg_function::sdef_to_json(input_path, filter, output_path);
+        rpkg_function::sdef_to_json(input_path, output_path);
     } else if (command == "-dev_dlge_names") {
         dev_function::dev_dlge_names(input_path, output_path);
     } else if (command == "-search_repo") {

--- a/src/temp.cpp
+++ b/src/temp.cpp
@@ -20,9 +20,7 @@
 #pragma comment(lib, "../thirdparty/zhmtools/ResourceLib_HM2.lib")
 #pragma comment(lib, "../thirdparty/zhmtools/ResourceLib_HM3.lib")
 
-temp::temp() {
-
-}
+temp::temp() = default;
 
 temp::temp(uint64_t rpkgs_index, uint64_t hash_index) {
     initialize_enum_map_h2();
@@ -613,7 +611,7 @@ void temp::temp_version_check() {
         LOG_AND_EXIT("Error: RPKG file " + rpkgs.at(temp_rpkg_index).rpkg_file_path + " could not be read.");
     }
 
-    file.seekg(rpkgs.at(temp_rpkg_index).hash.at(temp_hash_index).data.header.data_offset, file.beg);
+    file.seekg(rpkgs.at(temp_rpkg_index).hash.at(temp_hash_index).data.header.data_offset, std::ifstream::beg);
     file.read(temp_input_data.data(), temp_hash_size);
     file.close();
 
@@ -645,15 +643,15 @@ void temp::temp_version_check() {
 
     temp_position = 0x20;
 
-    std::memcpy(&temp_sub_entity_table_offset, &temp_data.data()[temp_position], 0x4);
+    std::memcpy(&temp_sub_entity_table_offset, &temp_data[temp_position], 0x4);
 
     temp_position = 0x28;
 
-    std::memcpy(&temp_after_sub_entity_table_offset, &temp_data.data()[temp_position], 0x4);
+    std::memcpy(&temp_after_sub_entity_table_offset, &temp_data[temp_position], 0x4);
 
     temp_position = 0x6C;
 
-    std::memcpy(&entity_count, &temp_data.data()[temp_position], 0x4);
+    std::memcpy(&entity_count, &temp_data[temp_position], 0x4);
 
     if (temp_sub_entity_table_offset == 0x60 && entity_count != 0xFFFFFFFF) {
         uint32_t temp_version_check = temp_after_sub_entity_table_offset - temp_sub_entity_table_offset;
@@ -810,7 +808,7 @@ void temp::get_entries_hash_reference_data(uint32_t entry_index) {
     }
 }
 
-void temp::get_temp_entries_data(std::string value_type, std::string type_string) {
+void temp::get_temp_entries_data(const std::string& value_type, std::string type_string) {
     std::vector<char>().swap(response_data);
 
     std::string propertyValues_string = "0";
@@ -1030,8 +1028,8 @@ void temp::get_temp_entries_data(std::string value_type, std::string type_string
 }
 
 void temp::json_temp_node_scan(const rapidjson::Value& node, std::string& propertyValues_string,
-                               std::string& nPropertyID_string, std::string& type_string, std::string json_pointer,
-                               std::string json_type) {
+                               std::string& nPropertyID_string, std::string& type_string, const std::string& json_pointer,
+                               const std::string& json_type) {
     bool output = true;
 
     std::stringstream ss;
@@ -1253,7 +1251,7 @@ void temp::json_temp_node_scan(const rapidjson::Value& node, std::string& proper
     }
 }
 
-void temp::get_entries_data(uint32_t entry_index, std::string value_type) {
+void temp::get_entries_data(uint32_t entry_index, const std::string& value_type) {
     std::vector<char>().swap(response_data);
 
     std::string propertyValues_string = "";

--- a/src/temp.h
+++ b/src/temp.h
@@ -36,13 +36,13 @@ public:
 
     void get_entries_hash_reference_data(uint32_t entry_index);
 
-    void get_temp_entries_data(std::string value_type, std::string type_string);
+    void get_temp_entries_data(const std::string& value_type, std::string type_string);
 
     void json_temp_node_scan(const rapidjson::Value& node, std::string& propertyValues_string,
-                             std::string& nPropertyID_string, std::string& type_string, std::string json_pointer,
-                             std::string json_type);
+                             std::string& nPropertyID_string, std::string& type_string, const std::string& json_pointer,
+                             const std::string& json_type);
 
-    void get_entries_data(uint32_t entry_index, std::string value_type);
+    void get_entries_data(uint32_t entry_index, const std::string& value_type);
 
     void
     json_node_scan(const rapidjson::Value& node, std::string& propertyValues_string, std::string& nPropertyID_string,


### PR DESCRIPTION
- Extracting redundant allocations (e.g. `bytes4`) into global compiler constants.
- Trying to make files look the same where possible to further extract common logic in future PRs