### PR TITLE
[RPKG] Restore hash_value, add hash_path

### DIFF
--- a/src/generate_hash_meta_json.cpp
+++ b/src/generate_hash_meta_json.cpp
@@ -6,7 +6,10 @@ std::string rpkg_function::generate_hash_meta_json(const uint64_t rpkg_index, co
 {
     // Output hash's meta data to JSON format
     nlohmann::ordered_json json;
-    json["hash_value"] = util::hash_to_ioi_string(rpkgs.at(rpkg_index).hash.at(hash_index).hash_value, true);
+    json["hash_value"] = util::uint64_t_to_hex_string(rpkgs.at(rpkg_index).hash.at(hash_index).hash_value);
+    if (std::string path = util::hash_to_ioi_string(rpkgs.at(rpkg_index).hash.at(hash_index).hash_value, false); path != "") {
+        json["hash_path"] = path;
+    }
     json["hash_offset"] = rpkgs.at(rpkg_index).hash.at(hash_index).data.header.data_offset;
     json["hash_size"] = rpkgs.at(rpkg_index).hash.at(hash_index).data.header.data_size;
     json["hash_resource_type"] = std::string(rpkgs.at(rpkg_index).hash.at(hash_index).hash_resource_type.data(), 4);

--- a/src/hash_meta_to_json.cpp
+++ b/src/hash_meta_to_json.cpp
@@ -39,7 +39,11 @@ void rpkg_function::hash_meta_to_json(std::string& input_path) {
         meta_file.read(input, sizeof(bytes8));
         std::memcpy(&bytes8, input, sizeof(bytes8));
         meta_data.hash_value = bytes8;
-        json_string += R"("hash_value":")" + util::hash_to_ioi_string(meta_data.hash_value, true) + "\",";
+        json_string += R"("hash_value":")" + util::uint64_t_to_hex_string(meta_data.hash_value) + "\",";
+
+        if (std::string path = util::hash_to_ioi_string(meta_data.hash_value, false); path != "") {
+            json_string += R"("hash_path":")" + path + "\",";
+        }
 
         meta_file.read(input, sizeof(bytes8));
         std::memcpy(&bytes8, input, sizeof(bytes8));

--- a/src/json_to_hash_meta.cpp
+++ b/src/json_to_hash_meta.cpp
@@ -60,7 +60,7 @@ void rpkg_function::json_to_hash_meta(std::string& input_path) {
 
     std::string temp_string = hash_value.GetString();
 
-    if (temp_string.substr(0, 1) == "[") {
+    if (!util::is_valid_hash(temp_string)) {
         temp_string = generic_function::compute_ioi_hash(temp_string);
     }
 


### PR DESCRIPTION
This restores the old functionality of converting hash meta to JSON, by keeping `hash_value` a hash, and adding a new `hash_path` (only added on meta -> JSON, not used for JSON -> meta) property with the path (if it is valid). If there is no valid path, `hash_path` will not be added.

JSON -> meta functionality has been slightly altered to check if the `hash_value` is not a valid hash.