### PR TITLE
Fix crashes when loading WWEV files from H2016

### DIFF
--- a/src/extract_wwev_to_ogg_from.cpp
+++ b/src/extract_wwev_to_ogg_from.cpp
@@ -265,6 +265,16 @@ void rpkg_function::extract_wwev_to_ogg_from(std::string& input_path, std::strin
 
                     std::memcpy(&wwev_file_count_test, &wwev_data->data()[position], sizeof(bytes4));
 
+                    if (wwev_file_count == -1 || wwev_file_count == 1 && wwev_file_count_test < 5000) {
+                        // Hitman 2016 file format has an extra int32 here
+                        // The 2000 in the check is a bit arbitrary, but I don't know anything better to test.
+                        // Will give false negatives (2016 wwev detected as newer version) if there are more than 5000 embedded sounds
+                        // Will give false positives (newer wwev detected as 2016 version) if there is exactly one embedded sound with a wem id lower than 5000
+                        // -grappigegovert
+                        wwev_file_count = wwev_file_count_test;
+                        position += 4;
+                    }
+
                     bool found = false;
 
                     uint64_t input_filter_index = 0;

--- a/src/lib/rpkg_dll.cpp
+++ b/src/lib/rpkg_dll.cpp
@@ -627,6 +627,16 @@ int create_ogg_file_from_hash_in_rpkg(char* rpkg_file, char* hash_string, int co
 
             std::memcpy(&wwev_file_count_test, &(*sound_data)[position], sizeof(bytes4));
 
+            if (wwev_file_count == -1 || wwev_file_count == 1 && wwev_file_count_test < 5000) {
+                // Hitman 2016 file format has an extra int32 here
+                // The 2000 in the check is a bit arbitrary, but I don't know anything better to test.
+                // Will give false negatives (2016 wwev detected as newer version) if there are more than 5000 embedded sounds
+                // Will give false positives (newer wwev detected as 2016 version) if there is exactly one embedded sound with a wem id lower than 5000
+                // -grappigegovert
+                wwev_file_count = wwev_file_count_test;
+                position += 4;
+            }
+
             std::string wem_ogg_path = util::uint64_t_to_hex_string(rpkg.hash.at(it->second).hash_value);
 
             if (command == 0) {


### PR DESCRIPTION
RPKG-Gui would crash (CTD) anytime you open a WWEV file from Hitman 2016, because it tries to automatically read the embedded sounds, and the file format has changed slightly since 2016.
This PR fixes that.

The CLI function `extract_wwev_to_ogg_from` appears to be using the same code, so I've changed that as well. I have not tested if that one indeed crashed / is fixed.